### PR TITLE
Log extension module messages.

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -6,6 +6,7 @@ from distutils.errors import CompileError, LinkError
 import hashlib
 import imp
 import importlib
+import logging
 import numpy
 import os
 from os.path import dirname, exists, expanduser, isdir, join
@@ -28,6 +29,9 @@ except ImportError:
 # Package imports.
 from .config import get_config  # noqa: 402
 from .capture_stream import CaptureMultipleStreams  # noqa: 402
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_platform_dir():
@@ -278,5 +282,6 @@ class ExtModule(object):
             return ec, el
 
     def _message(self, *args):
+        logger.info(args)
         if self.verbose:
             print(' '.join(args))

--- a/compyle/transpiler.py
+++ b/compyle/transpiler.py
@@ -280,7 +280,7 @@ class Transpiler(object):
     def compile(self):
         if self.backend == 'cython':
             self.source = self.get_code()
-            mod = ExtModule(self.source, verbose=True)
+            mod = ExtModule(self.source)
             self.mod = mod.load()
         elif self.backend == 'opencl':
             import pyopencl as cl


### PR DESCRIPTION
Set the default mode for cython to not be too verbose and instead log
messages.