### PR TITLE
Support for simple templates

### DIFF
--- a/compyle/ast_utils.py
+++ b/compyle/ast_utils.py
@@ -6,6 +6,8 @@ import sys
 
 PY_VER = sys.version_info.major
 
+basestring = str if PY_VER > 2 else basestring
+
 
 class NameLister(ast.NodeVisitor):
     """Utility class to collect the Names in an AST.
@@ -93,7 +95,7 @@ class SymbolParser(ast.NodeVisitor):
 
 
 def _get_tree(code):
-    return ast.parse(code) if isinstance(code, str) else code
+    return ast.parse(code) if isinstance(code, basestring) else code
 
 
 def get_symbols(code, ctx=(ast.Load, ast.Store)):
@@ -138,7 +140,7 @@ def get_unknown_names_and_calls(code):
     code: A code string or the result of an ast.parse.
 
     """
-    tree = ast.parse(code) if isinstance(code, str) else code
+    tree = ast.parse(code) if isinstance(code, basestring) else code
     p = SymbolParser()
     p.visit(tree)
     funcargs = p.funcargs

--- a/compyle/cython_generator.py
+++ b/compyle/cython_generator.py
@@ -22,6 +22,7 @@ from mako.template import Template
 from .types import KnownType, Undefined, get_declare_info
 from .config import get_config
 from .ast_utils import get_assigned, has_return
+from .utils import getsourcelines
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +215,7 @@ class CythonGenerator(object):
         (['int x', 'double* y'], ['x', 'y'])
 
         """
-        sourcelines = inspect.getsourcelines(func)[0]
+        sourcelines = getsourcelines(func)[0]
         defn, lines = get_func_definition(sourcelines)
         f_name, returns, args = self._analyze_method(func, lines)
         py_args = []
@@ -366,7 +367,7 @@ class CythonGenerator(object):
         return code
 
     def _get_method_wrapper(self, meth, indent=' ' * 8, declarations=None):
-        sourcelines = inspect.getsourcelines(meth)[0]
+        sourcelines = getsourcelines(meth)[0]
         defn, lines = get_func_definition(sourcelines)
         m_name, returns, args = self._analyze_method(meth, lines)
         c_defn = self._get_c_method_spec(m_name, returns, args)

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -12,6 +12,7 @@ from .transpiler import Transpiler, BUILTINS
 from .types import (dtype_to_ctype, get_declare_info,
                     dtype_to_knowntype, annotate)
 from .extern import Extern
+from .utils import getsourcelines
 
 from . import array
 from . import parallel
@@ -102,7 +103,7 @@ class AnnotationHelper(ast.NodeVisitor):
         return missing_decl
 
     def annotate(self):
-        src = dedent('\n'.join(inspect.getsourcelines(self.func)[0]))
+        src = dedent('\n'.join(getsourcelines(self.func)[0]))
         self._src = src.splitlines()
         code = ast.parse(src)
         self.visit(code)

--- a/compyle/template.py
+++ b/compyle/template.py
@@ -1,0 +1,74 @@
+import ast
+import inspect
+from textwrap import dedent
+
+import mako.template
+
+
+getfullargspec = getattr(
+    inspect, 'getfullargspec', inspect.getargspec
+)
+
+
+class Template(object):
+    def __init__(self, name):
+        self.name = name
+        self._function = None
+
+    @property
+    def function(self):
+        if self._function is None:
+            self._function = self._make_function()
+        return self._function
+
+    def _make_function(self):
+        src, annotations = self._get_code()
+        self._source = src
+        namespace = {}
+        exec(src, namespace)
+        f = namespace[self.name]
+        f.__module__ = self.__module__
+        try:
+            f.__annotations__ = annotations
+        except AttributeError:
+            f.im_func.__annotations__ = annotations
+        f.source = src
+        return f
+
+    def _get_code(self):
+        m = ast.parse(dedent(inspect.getsource(self.template)))
+        argspec = getfullargspec(self.template)
+        args = argspec.args
+        if args[0] == 'self':
+            args = args[1:]
+        arg_string = ', '.join(args)
+        body = m.body[0].body
+        template = body[-1].value.s
+        docstring = body[0].value.s if len(body) == 2 else ''
+        name = self.name
+        sig = 'def {name}({args}):\n    """{docs}\n    """'.format(
+            name=name, args=arg_string, docs=docstring
+        )
+        src = sig + self.render(template)
+        annotations = self.template.__annotations__ or {}
+        return src, annotations
+
+    def inject(self, s):
+        return s
+
+    def render(self, src):
+        t = mako.template.Template(text=src)
+        return t.render(obj=self)
+
+    def extra_args(self):
+        # XXX
+        return None
+
+    def template(self):
+        '''Override this to write your mako template.
+
+        `obj` is mapped to self.
+        '''
+        '''
+        ## Mako code here.
+        '''

--- a/compyle/template.py
+++ b/compyle/template.py
@@ -52,7 +52,7 @@ class Template(object):
             name=name, args=arg_string, docs=docstring
         )
         src = sig + self.render(template)
-        annotations = self.template.__annotations__ or {}
+        annotations = getattr(self.template, '__annotations__', {})
         annotations.update(extra_annotations)
         return src, annotations
 

--- a/compyle/tests/test_template.py
+++ b/compyle/tests/test_template.py
@@ -1,0 +1,96 @@
+from textwrap import dedent
+
+import numpy as np
+
+from ..array import wrap
+from ..types import annotate
+from ..template import Template
+from ..parallel import Elementwise
+
+
+class SimpleTemplate(Template):
+    def __init__(self, name, cond=False):
+        super(SimpleTemplate, self).__init__(name=name)
+        self.cond = cond
+
+    def template(self, x, y):
+        '''Docstring text'''
+        '''
+        % for i in range(5):
+        print(${i})
+        % endfor
+        % if obj.cond:
+        return 'hello'
+        % else:
+        return 'bye'
+        % endif
+        '''
+
+
+class Dummy(Template):
+    def template(self):
+        '''Docs'''
+        '''
+        print(123)
+        '''
+
+
+class ParallelExample(Template):
+    @annotate(i='int', x='doublep', y='doublep')
+    def template(self, i, x, y):
+        '''
+        y[i] = x[i]*2.0
+        '''
+
+
+def test_simple_template():
+    # Given
+    t = SimpleTemplate(name='simple')
+
+    # When
+    simple = t.function
+    x = simple(1, 2)
+
+    # Then
+    assert x == 'bye'
+
+    # Given
+    t = SimpleTemplate(name='simple', cond=True)
+
+    # When
+    simple = t.function
+    x = simple(1, 2)
+
+    # Then
+    assert x == 'hello'
+
+
+def test_that_source_code_is_available():
+    # Given/When
+    dummy = Dummy('dummy').function
+
+    # Then
+    expect = dedent('''\
+    def dummy():
+        """Docs
+        """
+        print(123)
+    ''')
+    assert dummy.source.strip() == expect.strip()
+
+
+def test_template_usable_in_code_generation():
+    # Given
+    twice = ParallelExample('twice').function
+
+    x = np.linspace(0, 1, 10)
+    y = np.zeros_like(x)
+    x, y = wrap(x, y)
+
+    # When
+    e = Elementwise(twice)
+    e(x, y)
+
+    # Then
+    y.pull()
+    np.testing.assert_almost_equal(y, 2.0*x.data)

--- a/compyle/tests/test_template.py
+++ b/compyle/tests/test_template.py
@@ -43,6 +43,16 @@ class ParallelExample(Template):
         '''
 
 
+class ExtraArgs(Template):
+    def extra_args(self):
+        return ['x'], {'x': 'int'}
+
+    def template(self):
+        '''
+        return x + 1
+        '''
+
+
 def test_simple_template():
     # Given
     t = SimpleTemplate(name='simple')
@@ -94,3 +104,50 @@ def test_template_usable_in_code_generation():
     # Then
     y.pull()
     np.testing.assert_almost_equal(y, 2.0*x.data)
+
+
+def test_template_with_extra_args():
+    # Given
+    extra = ExtraArgs('extra').function
+
+    # When
+    result = extra(1)
+
+    # Then
+    assert result == 2
+    assert extra.__annotations__ == {'x': 'int'}
+
+
+def test_template_inject_works():
+    # Given
+    def f(x):
+        '''Docs
+        '''
+        for i in range(5):
+            x += i
+        return x + 1
+
+    # When
+    t = Template('t')
+    result = t.inject(f, indent=1)
+
+    # Then
+    lines = ['for i in range(5):\n', '    x += i\n', 'return x + 1\n']
+    expect = ''.join([' '*4 + x for x in lines])
+    assert result == expect
+
+    # When
+    result = t.inject(f, indent=2)
+
+    # Then
+    lines = ['for i in range(5):\n', '    x += i\n', 'return x + 1\n']
+    expect = ''.join([' '*8 + x for x in lines])
+    assert result == expect
+
+    # When
+    result = t.inject(f, indent=0)
+
+    # Then
+    lines = ['for i in range(5):\n', '    x += i\n', 'return x + 1\n']
+    expect = ''.join(lines)
+    assert result == expect

--- a/compyle/tests/test_utils.py
+++ b/compyle/tests/test_utils.py
@@ -1,0 +1,59 @@
+import inspect
+from textwrap import dedent
+from unittest import TestCase
+
+from .. import utils
+
+
+def func(x):
+    return x
+
+
+class TestUtils(TestCase):
+    def test_getsource_works_with_normal_function(self):
+        # Given/When
+        src = utils.getsource(func)
+
+        # Then
+        self.assertEqual(src, inspect.getsource(func))
+
+    def test_getsource_works_with_generated_function(self):
+        # Given
+        src = dedent('''
+        def gfunc(x):
+            return x
+        ''')
+        ns = {}
+        exec(src, ns)
+        gfunc = ns['gfunc']
+        gfunc.source = src
+
+        # When
+        result = utils.getsource(gfunc)
+
+        # Then
+        self.assertEqual(result, src)
+
+    def test_getsourcelines_works_with_normal_function(self):
+        # Given/When
+        result = utils.getsourcelines(func)
+
+        # Then
+        self.assertEqual(result, inspect.getsourcelines(func))
+
+    def test_getsourcelines_works_with_generated_function(self):
+        # Given
+        src = dedent('''
+        def gfunc(x):
+            return x
+        ''')
+        ns = {}
+        exec(src, ns)
+        gfunc = ns['gfunc']
+        gfunc.source = src
+
+        # When
+        result = utils.getsourcelines(gfunc)
+
+        # Then
+        self.assertEqual(result, (src.splitlines(True), 0))

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -12,7 +12,6 @@ tested and modified to be suitable for use with PySPH.
 from __future__ import absolute_import
 
 import ast
-import inspect
 import re
 import sys
 from textwrap import dedent, wrap
@@ -26,6 +25,7 @@ from .types import get_declare_info
 from .cython_generator import (
     CodeGenerationError, KnownType, Undefined, all_numeric
 )
+from .utils import getsource
 
 PY_VER = sys.version_info.major
 
@@ -279,7 +279,7 @@ class CConverter(ast.NodeVisitor):
 
     def parse_instance(self, obj, ignore_methods=None):
         code = self.get_struct_from_instance(obj)
-        src = dedent(inspect.getsource(obj.__class__))
+        src = dedent(getsource(obj.__class__))
         ignore_methods = [] if ignore_methods is None else ignore_methods
         for method in dir(obj):
             if not method.startswith(('_', 'py_')) \
@@ -291,7 +291,7 @@ class CConverter(ast.NodeVisitor):
         return code
 
     def parse_function(self, obj, declarations=None):
-        src = dedent(inspect.getsource(obj))
+        src = dedent(getsource(obj))
         fname = obj.__name__
         self._declarations = declarations
         self._annotations[fname] = getattr(obj, '__annotations__', None)

--- a/compyle/transpiler.py
+++ b/compyle/transpiler.py
@@ -1,4 +1,3 @@
-import inspect
 import importlib
 import math
 import re
@@ -12,7 +11,7 @@ from .cython_generator import CythonGenerator, CodeGenerationError
 from .translator import OpenCLConverter, CUDAConverter
 from .ext_module import ExtModule
 from .extern import Extern, get_extern_code
-
+from .utils import getsourcelines
 
 BUILTINS = set(
     [x for x in dir(math) if not x.startswith('_')] +
@@ -66,7 +65,7 @@ def get_external_symbols_and_calls(func, backend):
     else:
         ignore = OCL_BUILTIN_SYMBOLS
 
-    src = dedent('\n'.join(inspect.getsourcelines(func)[0]))
+    src = dedent('\n'.join(getsourcelines(func)[0]))
     names, calls = get_unknown_names_and_calls(src)
     names -= ignore
     calls = filter_calls(calls)

--- a/compyle/utils.py
+++ b/compyle/utils.py
@@ -1,0 +1,27 @@
+import inspect
+
+
+def getsourcelines(obj):
+    '''Given an object return the source code that defines it as a list of lines
+    along with the starting line.
+
+    '''
+    try:
+        return inspect.getsourcelines(obj)
+    except Exception:
+        if hasattr(obj, 'source'):
+            return obj.source.splitlines(True), 0
+        else:
+            raise
+
+
+def getsource(obj):
+    '''Given an object return the source that defines it.
+    '''
+    try:
+        return inspect.getsource(obj)
+    except Exception:
+        if hasattr(obj, 'source'):
+            return obj.source
+        else:
+            raise

--- a/compyle/utils.py
+++ b/compyle/utils.py
@@ -2,9 +2,8 @@ import inspect
 
 
 def getsourcelines(obj):
-    '''Given an object return the source code that defines it as a list of lines
-    along with the starting line.
-
+    '''Given an object return the source code that defines it as a list of
+    lines along with the starting line.
     '''
     try:
         return inspect.getsourcelines(obj)


### PR DESCRIPTION
This feature allows a user to write a simple class which uses mako to generate a function.  This should simplify auto-generating some of the functions we require with a relatively simple syntax.  The tests provide several examples.