### PR TITLE
Update massage_args method to fix issues with pyopencl

### DIFF
--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -280,7 +280,7 @@ class ElementwiseJIT(parallel.ElementwiseBase):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        elif isinstance(x, np.ndarray):
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
         else:
             return np.asarray(x)
@@ -353,7 +353,7 @@ class ReductionJIT(parallel.ReductionBase):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        elif isinstance(x, np.ndarray):
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
         else:
             return np.asarray(x)
@@ -459,7 +459,7 @@ class ScanJIT(parallel.ScanBase):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        elif isinstance(x, np.ndarray):
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
         else:
             return np.asarray(x)

--- a/compyle/parallel.py
+++ b/compyle/parallel.py
@@ -485,8 +485,10 @@ class ElementwiseBase(object):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        else:
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
+        else:
+            return np.asarray(x)
 
     def __call__(self, *args, **kw):
         c_args = [self._massage_arg(x) for x in args]
@@ -704,8 +706,10 @@ class ReductionBase(object):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        else:
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
+        else:
+            return np.asarray(x)
 
     def __call__(self, *args):
         c_args = [self._massage_arg(x) for x in args]
@@ -1061,8 +1065,10 @@ class ScanBase(object):
     def _massage_arg(self, x):
         if isinstance(x, array.Array):
             return x.dev
-        else:
+        elif self.backend != 'cuda' or isinstance(x, np.ndarray):
             return x
+        else:
+            return np.asarray(x)
 
     def __call__(self, **kwargs):
         c_args_dict = {k: self._massage_arg(x) for k, x in kwargs.items()}


### PR DESCRIPTION
Converting numpy arrays to non-integer scalar arguments is no longer supported by pyopencl