### PR TITLE
Work around bug in capturing output on windows.

### DIFF
--- a/compyle/tests/test_capture_stream.py
+++ b/compyle/tests/test_capture_stream.py
@@ -2,7 +2,12 @@ import subprocess
 import sys
 import unittest
 
+import pytest
+
 from ..capture_stream import CaptureMultipleStreams, CaptureStream
+
+if sys.platform.startswith("win32") and sys.version_info[:2] > (3, 5):
+    pytest.skip("skipping capture tests on windows", allow_module_level=True)
 
 
 def write_stderr():


### PR DESCRIPTION
On Windows with Python >= 3.6.0, the console handling seems to have
changed and this seems to break our capturing the file descriptor to
suppress the compilation messages on the console.  pytest has a fix
here: https://github.com/pytest-dev/pytest/pull/2462 but we essentially
do not do any capturing on windows for these Python versions as this fix
doesn't seem to help us here.  Hopefully this will be resolved in
Python itself at some point but for now this error was breaking any
compilation using compyle on Windows.