### PR TITLE
Add attribute needed to profiled kernel.

### DIFF
--- a/compyle/opencl.py
+++ b/compyle/opencl.py
@@ -72,6 +72,9 @@ def profile_kernel(kernel, name):
         return event
 
     if get_config().profile:
+        wgi = getattr(kernel, 'get_work_group_info', None)
+        if wgi is not None:
+            _profile_knl.get_work_group_info = wgi
         return _profile_knl
     else:
         return kernel


### PR DESCRIPTION
In some cases, we use the kernel's get_work_group_info which is not
available in the wrapped profile call so we add that.