### PR TITLE
Fix build errors when installing compyle.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 import sys
 from setuptools import setup, find_packages
-from Cython.Distutils import Extension
-from Cython.Build import cythonize
+
+try:
+    from Cython.Distutils import Extension
+    from Cython.Build import cythonize
+except ImportError:
+    from distutils.core import Extension
+
+    def cythonize(*args, **kw):
+        return args[0]
 
 
 def get_version():


### PR DESCRIPTION
The setup script expects Cython to be available but this cannot be
decided by pip so leads to a failure.