### PR TITLE
Minor fix to handle numpy arrays correctly.

### DIFF
--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -45,7 +45,12 @@ def getargspec(f):
 def get_ctype_from_arg(arg):
     if isinstance(arg, array.Array):
         return arg.gptr_type
-    elif isinstance(arg, np.ndarray) or isinstance(arg, np.floating):
+    elif isinstance(arg, np.ndarray):
+        if len(arg) > 1:
+            return dtype_to_knowntype(arg.dtype, address='global')
+        else:
+            return dtype_to_ctype(arg.dtype)
+    elif isinstance(arg, np.floating):
         return dtype_to_ctype(arg.dtype)
     else:
         if isinstance(arg, float):


### PR DESCRIPTION
We currently do not handle numpy arrays correctly and treat them as
scalars, instead we now check the length and if the length is > 1 we
treat them as arrays and not scalars.