### PR TITLE
Don't indiscriminately add /usr/local/include.

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -10,6 +10,7 @@ import logging
 import numpy
 import os
 from os.path import exists, expanduser, isdir, join
+import platform
 from pyximport import pyxbuild
 import shutil
 import sys
@@ -122,7 +123,7 @@ class ExtModule(object):
         self.extra_link_args = extra_link_args if extra_link_args else []
 
     def _add_local_include(self):
-        if sys.platform != 'win32':
+        if 'bsd' in platform.system().lower():
             local = '/usr/local/include'
             if local not in self.extra_inc_dirs:
                 self.extra_inc_dirs.append(local)


### PR DESCRIPTION
This led to a very subtle bug because of possibly incompatible headers
being accidentally used leading to very hard to debug segfaults.  We now
add the /usr/local/include only on BSD systems.