### PR TITLE
Fix cumsum

### DIFF
--- a/compyle/array.py
+++ b/compyle/array.py
@@ -603,10 +603,12 @@ def cumsum(ary, backend=None, out=None):
     if backend is None:
         backend = ary.backend
     if backend == 'opencl' or backend == 'cuda':
+        import compyle.parallel as parallel
         if out is None:
             out = empty(ary.length, ary.dtype, backend=backend)
-        cumsum_scan = Scan(inp_cumsum, out_cumsum, 'a+b',
-                           dtype=ary.dtype, backend=backend)
+        cumsum_scan = parallel.Scan(
+            inp_cumsum, out_cumsum, 'a+b', dtype=ary.dtype, backend=backend
+        )
         cumsum_scan(ary=ary, out=out)
         return out
     elif backend == 'cython':

--- a/compyle/low_level.py
+++ b/compyle/low_level.py
@@ -323,8 +323,8 @@ class _cast(Extern):
     def code(self, backend):
         return ''
 
-    def __call__(self, *args, **kw):
-        pass
+    def __call__(self, x, type_str):
+        return eval(type_str)(x)
 
 
 prange = _prange()

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -333,3 +333,19 @@ def test_dot(backend):
 
     # Then
     assert np.all(out_array == 32)
+
+
+@check_all_backends
+def test_cumsum(backend):
+    check_import(backend)
+
+    # Given
+    a = array.ones(100, dtype=int, backend=backend)
+
+    # When
+    b = array.cumsum(a)
+
+    # Then
+    a.pull()
+    b.pull()
+    assert np.all(b.data == np.cumsum(a.data))

--- a/compyle/tests/test_low_level.py
+++ b/compyle/tests/test_low_level.py
@@ -8,7 +8,7 @@ from ..array import wrap
 from ..types import annotate, declare
 from ..low_level import (
     Cython, Kernel, LocalMem, local_barrier, GID_0, LDIM_0, LID_0,
-    nogil, prange, parallel
+    nogil, prange, parallel, cast
 )
 
 
@@ -194,3 +194,11 @@ class TestCython(unittest.TestCase):
         self.assertEqual(fac(0), 1)
         self.assertEqual(fac(1), 1)
         self.assertEqual(fac(3), 6)
+
+
+def test_cast_works_in_pure_python():
+    x = cast(1.23, "int")
+    assert x == 1
+
+    y = cast(2, "float")
+    assert y == 2.0

--- a/compyle/tests/test_parallel.py
+++ b/compyle/tests/test_parallel.py
@@ -419,7 +419,7 @@ class TestParallelUtils(ParallelUtilsBase, unittest.TestCase):
 
         @annotate(int='i, prev_item, item, N', ary='intp',
                   unique='intp', unique_count='intp')
-        def output_f(i, prev_item, item, N, ary, unique, unique_count):
+        def output_f(i, N, ary, unique, unique_count, item, prev_item):
             if item != prev_item:
                 unique[item - 1] = ary[i]
             if i == N - 1:


### PR DESCRIPTION
- Fix a bug with array.cumsum.
- Scans required ignored arguments at the start, now they can be anywhere.
- `cast` was not usable from Python.