### PR TITLE
Fix the sdist to include Cython source files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include MANIFEST.in *.py *.rst *.yml *.txt *.toml
+recursive-include compyle *.pyx
+recursive-exclude compyle *.cpp
 recursive-include docs *.*
 recursive-include examples *.*
 recursive-exclude docs/build *.*


### PR DESCRIPTION
We were not including the `sort.pyx` file and there was no `__init__.py`
in the `thrust` directory.