### PR TITLE
This should resolve test_subscript and test_declare_matrix test in python3.9 #64

### DIFF
--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -700,7 +700,7 @@ class CConverter(ast.NodeVisitor):
         return r'"%s"' % node.s
 
     def visit_Subscript(self, node):
-        if isinstance(node.slice,ast.Constant):#print('ast_constant_for py3.9')
+        if isinstance(node.slice,ast.Constant):  #'ast_constant_for py3.9'
             return '%s[%s]' % (
                 self.visit(node.value), self.visit(node.slice)
             )

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -701,7 +701,7 @@ class CConverter(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         return '%s[%s]' % (
-            self.visit(node.value), self.visit(node.slice.value)
+            self.visit(node.value), self.visit(node.slice)
         )
 
     def visit_TryExcept(self, node):

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -700,7 +700,7 @@ class CConverter(ast.NodeVisitor):
         return r'"%s"' % node.s
 
     def visit_Subscript(self, node):
-        if isinstance(node.slice,ast.Constant):  #'ast_constant_for py3.9'
+        if isinstance(node.slice, ast.Constant):
             return '%s[%s]' % (
                 self.visit(node.value), self.visit(node.slice)
             )

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -701,7 +701,9 @@ class CConverter(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         if (isinstance(node.slice, ast.Constant) or
-            isinstance(node.slice, ast.Name) or  isinstance(node.slice, ast.BinOp)):
+            isinstance(node.slice, ast.Name) or
+            isinstance(node.slice, ast.BinOp) or
+            isinstance(node.slice, ast.Subscript)):
             return '%s[%s]' % (
                 self.visit(node.value), self.visit(node.slice)
             )

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -700,7 +700,7 @@ class CConverter(ast.NodeVisitor):
         return r'"%s"' % node.s
 
     def visit_Subscript(self, node):
-        if isinstance(node.slice, ast.Constant):
+        if isinstance(node.slice, ast.Constant) or isinstance(node.slice, ast.Name):
             return '%s[%s]' % (
                 self.visit(node.value), self.visit(node.slice)
             )

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -700,7 +700,8 @@ class CConverter(ast.NodeVisitor):
         return r'"%s"' % node.s
 
     def visit_Subscript(self, node):
-        if isinstance(node.slice, ast.Constant) or isinstance(node.slice, ast.Name):
+        if (isinstance(node.slice, ast.Constant) or
+            isinstance(node.slice, ast.Name) or  isinstance(node.slice, ast.BinOp)):
             return '%s[%s]' % (
                 self.visit(node.value), self.visit(node.slice)
             )

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -700,9 +700,14 @@ class CConverter(ast.NodeVisitor):
         return r'"%s"' % node.s
 
     def visit_Subscript(self, node):
-        return '%s[%s]' % (
-            self.visit(node.value), self.visit(node.slice)
-        )
+        if isinstance(node.slice,ast.Constant):#print('ast_constant_for py3.9')
+            return '%s[%s]' % (
+                self.visit(node.value), self.visit(node.slice)
+            )
+        else:
+            return '%s[%s]' % (
+                self.visit(node.value), self.visit(node.slice.value)
+            )
 
     def visit_TryExcept(self, node):
         self.error('Try/except not implemented.', node)


### PR DESCRIPTION
@prabhuramachandran ,As I am new to this can you check this out.
As new changes in ast in pyhton 3.9.

#64 

After this change 
```
-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================================== short test summary info ================================================================
FAILED compyle/tests/test_translator.py::test_annotated_function - AttributeError: 'Name' object has no attribute 'value'
FAILED compyle/tests/test_translator.py::test_cuda_conversion - AttributeError: 'Name' object has no attribute 'value'
FAILED compyle/tests/test_translator.py::test_opencl_conversion - AttributeError: 'Name' object has no attribute 'value'
FAILED compyle/tests/test_translator.py::test_cuda_local_conversion - AttributeError: 'Name' object has no attribute 'value'
=============================================== 4 failed, 201 passed, 91 skipped, 117 warnings in 7.14s ================================================
```
