### PR TITLE
Add minimal support for nested profiling.

### DIFF
--- a/compyle/api.py
+++ b/compyle/api.py
@@ -13,7 +13,7 @@ from .parallel import (
 )
 from .profile import (
     get_profile_info, named_profile, profile, profile_ctx, print_profile,
-    profile_kernel
+    profile_kernel, ProfileContext, profile2csv
 )
 from .translator import (
     CConverter, CStructHelper, OpenCLConverter, detect_type, ocl_detect_type,

--- a/compyle/tests/test_profile.py
+++ b/compyle/tests/test_profile.py
@@ -5,7 +5,9 @@ from pytest import importorskip
 
 from ..config import get_config, use_config
 from ..array import wrap, zeros, ones
-from ..profile import get_profile_info, named_profile, profile, profile_ctx
+from ..profile import (
+    get_profile_info, named_profile, profile, profile_ctx, ProfileContext
+)
 
 
 def axpb():
@@ -38,6 +40,11 @@ def profiled_axpb():
     axpb()
 
 
+@profile
+def nested():
+    profiled_axpb()
+
+
 @named_profile('prefix_sum', backend='opencl')
 def get_prefix_sum_knl():
     from ..opencl import get_queue, get_context
@@ -56,7 +63,7 @@ def test_profile_ctx():
         axpb()
 
     profile_info = get_profile_info()
-    assert profile_info['axpb']['calls'] == 1
+    assert profile_info[0]['axpb']['calls'] == 1
 
 
 def test_profile():
@@ -64,7 +71,7 @@ def test_profile():
         profiled_axpb()
 
     profile_info = get_profile_info()
-    assert profile_info['profiled_axpb']['calls'] == 100
+    assert profile_info[0]['profiled_axpb']['calls'] == 100
 
 
 def test_profile_method():
@@ -80,13 +87,13 @@ def test_profile_method():
 
     # Then
     profile_info = get_profile_info()
-    assert profile_info['A.f']['calls'] == 5
+    assert profile_info[0]['A.f']['calls'] == 5
 
     # For b.f(), b.name is my_name.
-    assert profile_info['my_name']['calls'] == 5
+    assert profile_info[0]['my_name']['calls'] == 5
 
     # profile was given an explicit name for b.named()
-    assert profile_info['explicit_name']['calls'] == 5
+    assert profile_info[0]['explicit_name']['calls'] == 5
 
 
 def test_named_profile():
@@ -97,4 +104,18 @@ def test_named_profile():
     knl(x.dev)
 
     profile_info = get_profile_info()
-    assert profile_info['prefix_sum']['calls'] == 1
+    assert profile_info[0]['prefix_sum']['calls'] == 1
+
+
+def test_nesting_and_context():
+    # When
+    p = ProfileContext('main')
+    nested()
+    p.stop()
+
+    # Then
+    prof = get_profile_info()
+    assert len(prof) == 3
+    assert prof[0]['main']['calls'] == 1
+    assert prof[1]['nested']['calls'] == 1
+    assert prof[2]['profiled_axpb']['calls'] == 1


### PR DESCRIPTION
- Allows us to nest profiled sections and see them as such.
- Right now this is very primitive as the full stack is not saved all we
  save is which level the call was made and the full time taken by the
  call.
- Also introduce a ProfileContext object for low level profile contexts
  useful in Cython.
- Also added a `profile2csv` function for convenience.