### PR TITLE
Add a common configuration file for options.

### DIFF
--- a/compyle/tests/test_ext_module.py
+++ b/compyle/tests/test_ext_module.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
-from distutils.sysconfig import get_config_var
-from io import open as io_open
+from io import StringIO, open as io_open
 import os
 from os.path import join, exists
 import shutil
@@ -15,7 +14,8 @@ try:
 except ImportError:
     import mock
 
-from ..ext_module import get_md5, ExtModule, get_ext_extension, get_unicode
+from ..ext_module import (get_md5, ExtModule, get_ext_extension, get_unicode,
+                          get_config_file_opts)
 
 
 def _check_write_source(root):
@@ -46,6 +46,34 @@ def _check_compile(root):
         # If it was called, do the copy to mimic the action.
         shutil.copy(*m.call_args[0])
     return m.call_count
+
+
+def test_get_config_file_opts():
+    # Given
+    cfg = dedent('''
+    OMP_CFLAGS = ['-fxxx']
+    OMP_LINK = ['-fyyy']
+    ''')
+    m = mock.mock_open(read_data=cfg)
+    with mock.patch('compyle.ext_module.open', m), \
+        mock.patch('compyle.ext_module.exists') as mock_exists:
+        # When
+        mock_exists.return_value = False
+        opts = get_config_file_opts()
+        print(opts)
+
+        # Then
+        assert 'OMP_CFLAGS' not in opts
+        assert 'OMP_LINK' not in opts
+
+        # When
+        mock_exists.return_value = True
+        opts = get_config_file_opts()
+        print(opts)
+
+        # Then
+        assert opts['OMP_CFLAGS'] == ['-fxxx']
+        assert opts['OMP_LINK'] == ['-fyyy']
 
 
 class TestMiscExtMod(TestCase):

--- a/compyle/tests/test_ext_module.py
+++ b/compyle/tests/test_ext_module.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from io import StringIO, open as io_open
+from io import open as io_open
 import os
 from os.path import join, exists
 import shutil
@@ -14,8 +14,10 @@ try:
 except ImportError:
     import mock
 
+import compyle.ext_module
+
 from ..ext_module import (get_md5, ExtModule, get_ext_extension, get_unicode,
-                          get_config_file_opts)
+                          get_config_file_opts, get_openmp_flags)
 
 
 def _check_write_source(root):
@@ -69,11 +71,31 @@ def test_get_config_file_opts():
         # When
         mock_exists.return_value = True
         opts = get_config_file_opts()
-        print(opts)
 
         # Then
         assert opts['OMP_CFLAGS'] == ['-fxxx']
         assert opts['OMP_LINK'] == ['-fyyy']
+
+
+def test_get_openmp_flags():
+    # Given/When
+    f = get_openmp_flags()
+
+    # Then
+    assert f[0] != ['-fxxx']
+    assert f[1] != ['-fyyy']
+    assert len(f[0]) > 0
+
+    # Given
+    m = dict(OMP_CFLAGS=['-fxxx'], OMP_LINK=['-fyyy'])
+
+    with mock.patch.object(compyle.ext_module, 'CONFIG_OPTS', m):
+        # When
+        f = get_openmp_flags()
+
+        # Then
+        assert f[0] == ['-fxxx']
+        assert f[1] == ['-fyyy']
 
 
 class TestMiscExtMod(TestCase):

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -99,7 +99,8 @@ deployment target and the current version of XCode that you have installed is
 not compatible with that. By setting the environment variable you allow
 compyle to use a newer version. If this works, it is a good idea to set this
 in your default environment (``.bashrc`` for bash shells) so you do not have
-to do this every time.
+to do this every time. You may also do this in the compyle configuration file,
+see :ref:`config`.
 
 
 
@@ -135,7 +136,8 @@ installed, otherwise the important header files are not available. See
 `how-to-install-xcode-command-line-tools
 <https://stackoverflow.com/questions/9329243/how-to-install-xcode-command-line-tools>`_
 for more details. You may also want to set these environment variables in your
-``.bashrc`` so you don't have to do this every time.
+``.bashrc`` so you don't have to do this every time. You may also do this in
+the compyle configuration file, see :ref:`config`.
 
 Once you do this, compyle will automatically use this version of GCC and will
 also work with OpenMP. Note that on some preliminary benchmarks, GCC's OpenMP
@@ -171,3 +173,35 @@ If you want to use OpenCL support, you will need to install the ``pyopencl``
 package (``conda install -c conda-forge pyopencl`` or ``pip install
 pyopencl``). For CUDA Support, you will need to install ``pycuda`` and
 ``cupy``. Of course this assumes you have the required hardware for this.
+
+
+.. _config:
+
+Using the configuration file
+-----------------------------
+
+Instead of setting environment variables and build options on the shell you
+can have them setup using a simple configuration file.
+
+The file is located in ``~/.compyle/config.py``. Here ``~`` is your home
+directory which on Linux is ``/home/username``, on MacOS ``/Users/username``
+and on Windows the location is likely ``\Users\username``. This file is
+executed and certain options may be set there.
+
+For example if you wish to set the environment variables ``CC`` and ``CXX``
+you could do this in the ``config.py``::
+
+  import os
+
+  os.environ['CC'] = 'gcc-9'
+  os.environ['CXX'] = 'g++-9'
+
+If you are using an atypical compiler like icc, Cray, or PGI, you can set
+these up here too. You may also setup custom OpenMP related flags. For
+example, on a Cray system you may do the following::
+
+  OMP_CFLAGS = ['-homp']
+  OMP_LINK = ['-homp']
+
+The ``OMP_CFLAGS`` and ``OMP_LINK`` parameters should be lists. Other packages
+like pyzoltan or pysph may also use this file for customizations.


### PR DESCRIPTION
- This can be used to set environment variables, like CC/CXX.
- This can also be used to set custom OpenMP flag/link options.