### PR TITLE
Fix issues with capturing stdio on notebooks.

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -22,8 +22,6 @@ if sys.platform == 'win32':
 else:
     from distutils.extension import Extension
 
-PY3 = sys.version_info.major > 2
-
 # Package imports.
 from .config import get_config  # noqa: 402
 from .capture_stream import CaptureMultipleStreams  # noqa: 402
@@ -76,13 +74,6 @@ def get_md5(data):
     """Return the MD5 sum of the given data.
     """
     return hashlib.md5(data.encode()).hexdigest()
-
-
-def get_unicode(s):
-    if PY3:
-        return s
-    else:
-        return unicode(s)
 
 
 def get_openmp_flags():
@@ -197,7 +188,7 @@ class ExtModule(object):
     def _write_source(self, path):
         if not exists(path):
             with io.open(path, 'w', encoding='utf-8') as f:
-                f.write(get_unicode(self.code))
+                f.write(self.code)
 
     def _setup_root(self, root):
         if root is None:
@@ -279,8 +270,9 @@ class ExtModule(object):
             except (CompileError, LinkError):
                 hline = "*"*80
                 print(hline + "\nERROR")
-                print(stream.get_output()[0])
-                print(stream.get_output()[1])
+                s_out = stream.get_output()
+                print(s_out[0])
+                print(s_out[1])
                 msg = "Compilation of code failed, please check "\
                       "error messages above."
                 print(hline + "\n" + msg)

--- a/compyle/tests/test_ext_module.py
+++ b/compyle/tests/test_ext_module.py
@@ -16,7 +16,7 @@ except ImportError:
 
 import compyle.ext_module
 
-from ..ext_module import (get_md5, ExtModule, get_ext_extension, get_unicode,
+from ..ext_module import (get_md5, ExtModule, get_ext_extension,
                           get_config_file_opts, get_openmp_flags)
 
 
@@ -30,7 +30,7 @@ def _check_write_source(root):
 
     def _side_effect(*args, **kw):
         with io_open(*args, **kw) as fp:
-            fp.write(get_unicode("junk"))
+            fp.write("junk")
         return orig_side_effect(*args, **kw)
     m.side_effect = _side_effect
 


### PR DESCRIPTION
On a jupyter notebook, the output capturing when building extensions
automatically was broken.  This is a hacky fix for it but seems to work
reasonably well.  Also removed some older python 2/3 related workarounds
that are no longer needed.