### PR TITLE
Fix return visit in JIT and fix unsigned types handling in binop

### DIFF
--- a/compyle/tests/test_jit.py
+++ b/compyle/tests/test_jit.py
@@ -438,6 +438,22 @@ class TestAnnotationHelper(unittest.TestCase):
         # Then
         assert helper.arg_types['return_'] == 'intp'
 
+        # When
+        types = {'a': 'int', 'b': 'guintp'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'guintp'
+
+        # When
+        types = {'a': 'uint', 'b': 'guintp'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'guintp'
+
     def test_cast_return_type(self):
         # Given
         @annotate
@@ -531,3 +547,34 @@ class TestAnnotationHelper(unittest.TestCase):
 
         # Then
         assert helper.undecl_var_types['i'] == 'int'
+
+    def test_no_return_value(self):
+        # Given
+        @annotate
+        def f_no_return(a, n):
+            for i in range(n):
+                a[i] += 1
+            return
+
+        # When
+        types = {'a': 'guintp', 'n': 'int'}
+        helper = AnnotationHelper(f_no_return, types)
+        helper.annotate()
+
+        # Then
+        assert 'return_' not in helper.arg_types
+
+        # Given
+        @annotate
+        def f_return(a, n):
+            for i in range(n):
+                a[i] += 1
+            return n
+
+        # When
+        helper = AnnotationHelper(f_return, types)
+        helper.annotate()
+
+        # Then
+        assert 'return_' in helper.arg_types and \
+            helper.arg_types['return_'] == 'int'


### PR DESCRIPTION
- Empty return statement shouldn't default to double, it should be void
- Allow unsigned int + pointer in binop return type