### PR TITLE
array-utilities

### DIFF
--- a/compyle/array.py
+++ b/compyle/array.py
@@ -371,10 +371,12 @@ def arange(start, stop, step, dtype=np.int32, backend='cython'):
         out = np.arange(start, stop, step, dtype=dtype)
     return wrap_array(out, backend)
 
-def linspace(start, stop, num, dtype=np.float64, backend='opencl', endpoint=True):
-    if not type(num)==int:
+
+def linspace(start, stop, num, dtype=np.float64, backend='opencl',
+             endpoint=True):
+    if not type(num) == int:
         raise Exception("num should be an integer")
-    if num<=0:
+    if num <= 0:
         raise Exception('num should be greater than 0')
     if backend == 'opencl':
         import pyopencl.array as gpuarray
@@ -383,27 +385,22 @@ def linspace(start, stop, num, dtype=np.float64, backend='opencl', endpoint=True
             delta = (stop-start)/(num-1)
         else:
             delta = (stop-start)/num
-        out = gpuarray.arange(get_queue(), 0, num, 
+        out = gpuarray.arange(get_queue(), 0, num,
                               1, dtype=dtype)
-        out = out*delta+start
-    elif backend=='cuda':
+        out = out * delta+start
+    elif backend == 'cuda':
         import pycuda.gpuarray as gpuarray
         import pycuda.autoinit
         if endpoint:
             delta = (stop-start)/(num-1)
         else:
             delta = (stop-start)/num
-        
         out = gpuarray.arange(0, num, 1, dtype=dtype)
         out = out*delta+start
     else:
         out = np.linspace(start, stop, num,
-                         endpoint=endpoint, dtype=dtype)
+                          endpoint=endpoint, dtype=dtype)
     return wrap_array(out, backend)
-
-
-    return wrap_array(out, backend)
-
 
 
 def minimum(ary, backend=None):

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -409,6 +409,7 @@ def nDiff(i, y, x, b, lb):
     for it in range(lb):
         y[i] += x[it+i] * b[it]
 
+
 def diff(a, n, backend=None):
     """
     calculate the first discrete difference of the given array.
@@ -423,8 +424,10 @@ def diff(a, n, backend=None):
         raise ValueError(
             "order must be non-negative but got " + repr(n))
     if(a.__len__() < n+1):
-        raise ValueError('Array a should have length at least n+1, but got {}'.format(a.__len__()))
-    
+        raise ValueError(
+            "Array a should have length at least n+1, but got "
+            + str(a.__len__()))
+
     if backend is None:
         backend = a.backend
 
@@ -434,7 +437,7 @@ def diff(a, n, backend=None):
         binom_coeff = np.zeros(n+1)
         sign_fac = 1 if (n % 2 == 0) else -1
         for i in range(n+1):
-            binom_coeff[i] = ss.comb(n,i) * (-1)**i * sign_fac
+            binom_coeff[i] = ss.comb(n, i) * (-1)**i * sign_fac
         binom_coeff = wrap(binom_coeff, backend=backend)
         len_ar = a.__len__()
         y = zeros(len_ar - n, dtype=a.dtype, backend=backend)
@@ -498,7 +501,7 @@ def dot(a, b, backend=None):
 
 
 def trapz(y, x=None, dx=1.0, backend=None):
-    if backend == None:
+    if backend is None:
         backend = y.backend
     if x is None:
         d = dx

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -371,6 +371,40 @@ def arange(start, stop, step, dtype=np.int32, backend='cython'):
         out = np.arange(start, stop, step, dtype=dtype)
     return wrap_array(out, backend)
 
+def linspace(start, stop, num, dtype=np.float64, backend='opencl', endpoint=True):
+    if not type(num)==int:
+        raise Exception("num should be an integer")
+    if num<=0:
+        raise Exception('num should be greater than 0')
+    if backend == 'opencl':
+        import pyopencl.array as gpuarray
+        from .opencl import get_queue
+        if endpoint:
+            delta = (stop-start)/(num-1)
+        else:
+            delta = (stop-start)/num
+        out = gpuarray.arange(get_queue(), 0, num, 
+                              1, dtype=dtype)
+        out = out*delta+start
+    elif backend=='cuda':
+        import pycuda.gpuarray as gpuarray
+        import pycuda.autoinit
+        if endpoint:
+            delta = (stop-start)/(num-1)
+        else:
+            delta = (stop-start)/num
+        
+        out = gpuarray.arange(0, num, 1, dtype=dtype)
+        out = out*delta+start
+    else:
+        out = np.linspace(start, stop, num,
+                         endpoint=endpoint, dtype=dtype)
+    return wrap_array(out, backend)
+
+
+    return wrap_array(out, backend)
+
+
 
 def minimum(ary, backend=None):
     if backend is None:

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -421,9 +421,7 @@ def diff(a, n, backend=None):
     """
     calculate the first discrete difference of the given array.
 
-    The first difference is given by ``out[i] = a[i+1] - a[i]`` along
-    the given axis, higher differences are calculated by using `diff`
-    recursively.
+    The first difference is given by ``out[i] = a[i+1] - a[i]``
     """
     if n == 0:
         return a

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -12,24 +12,14 @@ from .sort import radix_sort
 from .profile import profile
 from .parallel import Elementwise
 
-
 try:
     import pycuda
     from .cuda import set_context
     set_context()
-    # if pycuda.VERSION >= (2014, 1):
-    if True:
-        def cu_bufint(arr, nbytes, offset):
-            return arr.gpudata.as_buffer(nbytes, offset)
-    else:
-        import cffi
-        ffi = cffi.FFI()
 
-        def cu_bufint(arr, nbytes, offset):
-            return ffi.buffer(
-                ffi.cast('void *', arr.ptr + arr.itemsize * offset),
-                nbytes
-            )
+    def cu_bufint(arr, nbytes, offset):
+        return arr.gpudata.as_buffer(nbytes, offset)
+
 except ImportError as e:
     pass
 

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -511,14 +511,14 @@ def trapz(y, x=None, dx=1.0, backend=None):
         d = dx
         out = (sum(y, backend=backend) - 0.5 * (y[0] + y[-1])) * d
     else:
-        if not len(x) == (len(y)):
+        if not len(x) == len(y):
             raise Exception('arrays x and y should be of the same size')
         d = diff(x, 1, backend=backend)
         sum_ar = (y[:-1] + y[1:])
         out = dot(d, sum_ar) * 0.5
     return out
 
-
+@annotate
 def where_elwise(i, condition, x, y,  ans):
     if condition[i]:
         ans[i] = x[i]
@@ -528,8 +528,7 @@ def where_elwise(i, condition, x, y,  ans):
 
 @memoize
 def where_kernel(backend, dtype):
-    where_annotated = annotate(where_elwise)
-    e = Elementwise(where_annotated, backend=backend)
+    e = Elementwise(where_elwise, backend=backend)
     return e
 
 

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 import mako.template as mkt
 import time
 from pytools import memoize, memoize_method
@@ -415,6 +416,10 @@ def nDiff(i, y, x, b, lb):
         y[i] += x[it+i] * b[it]
 
 
+def choose(n, x):
+    return math.factorial(n)/(math.factorial(n-x) * math.factorial(x))
+
+
 def diff(a, n, backend=None):
     """
     calculate the first discrete difference of the given array.
@@ -438,11 +443,10 @@ def diff(a, n, backend=None):
 
     if backend == 'opencl' or backend == 'cuda':
         from compyle.api import Elementwise
-        import scipy.special as ss
         binom_coeff = np.zeros(n+1)
         sign_fac = 1 if (n % 2 == 0) else -1
         for i in range(n+1):
-            binom_coeff[i] = ss.comb(n, i) * (-1)**i * sign_fac
+            binom_coeff[i] = choose(n, i) * (-1)**i * sign_fac
         binom_coeff = wrap(binom_coeff, backend=backend)
         len_ar = a.__len__()
         y = zeros(len_ar - n, dtype=a.dtype, backend=backend)

--- a/compyle/cuda.py
+++ b/compyle/cuda.py
@@ -11,6 +11,7 @@ import pycuda._mymako as mako
 from pycuda.tools import (dtype_to_ctype, bitlog2,
                           context_dependent_memoize, ScalarArg, VectorArg)
 import pycuda.gpuarray as gpuarray
+from compyle.thrust.sort import argsort
 import pycuda.driver as drv
 from pycuda.compiler import SourceModule as _SourceModule
 from pytools import memoize

--- a/compyle/cuda.py
+++ b/compyle/cuda.py
@@ -11,7 +11,6 @@ import pycuda._mymako as mako
 from pycuda.tools import (dtype_to_ctype, bitlog2,
                           context_dependent_memoize, ScalarArg, VectorArg)
 import pycuda.gpuarray as gpuarray
-from compyle.thrust.sort import argsort
 import pycuda.driver as drv
 from pycuda.compiler import SourceModule as _SourceModule
 from pytools import memoize

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -1,14 +1,17 @@
 import pytest
 import numpy as np
 
-from ..array import Array
-from ..config import get_config
+from ..array import Array, wrap_array
+from ..config import Config, get_config
 import compyle.array as array
-from compyle.api import wrap
+from compyle import config
 
 
 check_all_backends = pytest.mark.parametrize('backend',
                                              ['cython', 'opencl', 'cuda'])
+
+check_all_dtypes = pytest.mark.parametrize('dtype',
+                                           [np.int32, np.float32, np.float64])
 
 
 def make_dev_array(backend, n=16):
@@ -318,6 +321,25 @@ def test_sort_by_keys_with_output(backend):
     assert np.all(out_arrays[1].get() == act_result2)
 
 
+@pytest.mark.parametrize(
+    'backend', ['cython', 'cuda',
+                pytest.param('opencl', marks=pytest.mark.xfail)]
+)
+def test_argsort(backend):
+    check_import(backend)
+
+    # Given
+    nparr1 = np.random.randint(0, 100, 16, dtype=np.int32)
+    devarr1 = array.wrap(nparr1, backend=backend)
+
+    # When
+    out = array.argsort(devarr1)
+
+    # Then
+    ans = np.argsort(nparr1)
+    assert np.all(out.get() == ans)
+
+
 @check_all_backends
 def test_dot(backend):
     check_import(backend)
@@ -394,7 +416,7 @@ def test_diff(backend):
     assert(y[0] == 0)
     dev_array = np.linspace(0, 10, 11, dtype=np.float32)**2
     yt = np.diff(dev_array, 2)
-    dev_array = wrap(dev_array, backend=backend)
+    dev_array = wrap_array(dev_array, backend=backend)
     y = array.diff(dev_array, 2)
     for i in range(8):
         assert(y[i] == yt[i])
@@ -414,3 +436,138 @@ def test_trapz(backend):
     x = array.linspace(0, 5, 5, dtype=np.float32, backend=backend)
     with pytest.raises(Exception):
         array.trapz(y, x)
+
+
+check_comparison_methods = pytest.mark.parametrize(
+    'method', ['__gt__', '__lt__', '__ge__', '__le__', '__ne__', '__eq__'])
+
+
+@check_all_backends
+@check_all_dtypes
+@check_comparison_methods
+def test_comparison(backend, dtype, method):
+    check_import(backend)
+    if dtype == np.float64:
+        get_config().use_double = True
+    # Given
+    x = array.arange(0., 10., 1., dtype=dtype, backend=backend)
+
+    # When
+    out = x.__getattribute__(method)(5)
+
+    # Then
+    x_np = np.arange(10, dtype=dtype)
+    comp = [int(i) for i in x_np.__getattribute__(method)(5)]
+
+    assert np.all(out.get() == comp)
+
+
+@check_all_backends
+def test_where(backend):
+    check_import(backend)
+    # Given
+    a = array.arange(0, 10, 1, backend=backend)
+    b = array.arange(10, 20, 1, backend=backend)
+
+    # When
+    out = np.array([10, 11, 12, 13, 14, 15, 6, 7, 8, 9])
+
+    # Then
+    ans = array.where(a > 5, a, b)
+    assert np.all(ans.get() == out)
+
+
+def test_where_for_raised_errors():
+    check_import('opencl')
+    check_import('cuda')
+    # check errors
+    a = array.arange(0, 10, 1, backend='opencl', dtype=np.int32)
+    b = array.arange(10, 20, 1, backend='cuda', dtype=np.int32)
+    with pytest.raises(TypeError):
+        array.where(a > 5, a, b)
+    b = array.arange(10, 20, 1, backend='opencl', dtype=np.float32)
+    with pytest.raises(TypeError):
+        array.where(a > 5, a, b)
+
+
+@check_all_backends
+def test_ones_like(backend):
+    check_import(backend)
+    # Given
+    x = array.arange(1, 10, 1, dtype=np.int32)
+
+    # When
+    y = array.ones_like(x)
+    z = array.zeros_like(x)
+
+    # Then
+    assert np.all(y.get() == np.ones_like(x))
+    assert np.all(z.get() == np.zeros_like(x))
+
+
+@check_all_dtypes
+@check_all_backends
+def test_minimum(dtype, backend):
+    check_import(backend)
+
+    # Given
+    x = array.arange(3, 5, 1, backend=backend, dtype=dtype)
+
+    # When
+    out = array.minimum(x)
+
+    # Then
+    assert (out == 3)
+
+
+@check_all_dtypes
+@check_all_backends
+def test_sum(dtype, backend):
+    check_import(backend)
+
+    # Given
+    x = array.arange(0, 5, 1, backend=backend, dtype=dtype)
+
+    # When
+    out = array.sum(x)
+
+    # Then
+    assert (out == 10)
+
+
+@check_all_dtypes
+@check_all_backends
+def test_take_bool(dtype, backend):
+    check_import(backend)
+    if dtype == np.float64:
+        get_config().use_double = True
+
+    # Given
+    x = array.arange(0, 10, 1, backend=backend, dtype=dtype)
+    cond = x > 5
+
+    # When
+    out = array.take_bool(x, cond)
+
+    # Then
+    ans = np.arange(6, 10, dtype=dtype)
+
+    assert np.all(out.get() == ans)
+
+
+@check_all_backends
+def test_binary_op(backend):
+    check_import(backend)
+
+    # Given
+    x = array.ones(10, dtype=np.float32, backend=backend)
+    y = array.ones_like(x)
+    x_np = np.ones(10, dtype=np.float32)
+
+    # When
+    out_add = x + y
+    out_sub = x - y
+
+    # Then
+    assert np.all(out_add.get() == x_np + x_np)
+    assert np.all(out_sub.get() == np.zeros_like(x_np))

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -374,3 +374,33 @@ def test_linspace(backend):
     assert(dev_array[-1] < 10)
     dtype = dev_array.dtype
     assert(np.issubdtype(dtype, np.floating))
+
+
+@check_all_backends
+def test_diff(backend):
+    check_import(backend)
+    dev_array = array.ones(2, dtype=np.float32, backend=backend)
+    y = array.diff(dev_array, 1, backend=backend)
+    assert(y.__len__() == 1)
+    assert(y[0] == 0)
+    dev_array = np.linspace(0, 10, 11, dtype=np.float32)**2
+    yt = np.diff(dev_array, 2)
+    dev_array = wrap(dev_array, backend=backend)
+    y = array.diff(dev_array, 2, backend=backend)
+    for i in range(8):
+        assert(y[i] == yt[i])
+
+@check_all_backends
+def test_trapz(backend):
+    check_import(backend)
+    x = array.linspace(0, 5, 6, dtype=np.float32, backend=backend)
+    y = array.linspace(0, 5, 6, dtype=np.float32, backend=backend)
+    xn = np.linspace(0, 5, 6, dtype=np.float32)
+    yn = np.linspace(0, 5, 6, dtype=np.float32)
+    assert(array.trapz(y) == np.trapz(yn))
+    assert(array.trapz(y, x,) == np.trapz(yn, xn))
+    assert(array.trapz(y, dx=3) == np.trapz(yn, dx=3))
+
+    x = array.linspace(0, 5, 5, dtype=np.float32, backend=backend)
+    with pytest.raises(Exception):
+        array.trapz(y, x)

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -4,6 +4,7 @@ import numpy as np
 from ..array import Array
 from ..config import get_config
 import compyle.array as array
+from compyle.api import wrap
 
 
 check_all_backends = pytest.mark.parametrize('backend',
@@ -379,16 +380,25 @@ def test_linspace(backend):
 @check_all_backends
 def test_diff(backend):
     check_import(backend)
+    dev_array = array.ones(1, dtype=np.float32, backend=backend)
+    with pytest.raises(ValueError):
+        y = array.diff(dev_array, 1)
+    y = array.diff(dev_array, 0)
+    assert(y[0] == dev_array[0])
+
     dev_array = array.ones(2, dtype=np.float32, backend=backend)
-    y = array.diff(dev_array, 1, backend=backend)
+    with pytest.raises(ValueError):
+        y = array.diff(dev_array, -1)
+    y = array.diff(dev_array, 1)
     assert(y.__len__() == 1)
     assert(y[0] == 0)
     dev_array = np.linspace(0, 10, 11, dtype=np.float32)**2
     yt = np.diff(dev_array, 2)
     dev_array = wrap(dev_array, backend=backend)
-    y = array.diff(dev_array, 2, backend=backend)
+    y = array.diff(dev_array, 2)
     for i in range(8):
         assert(y[i] == yt[i])
+
 
 @check_all_backends
 def test_trapz(backend):

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -400,21 +400,24 @@ def test_linspace(backend):
 
 
 @check_all_backends
-def test_diff(backend):
+@check_all_dtypes
+def test_diff(backend, dtype):
     check_import(backend)
-    dev_array = array.ones(1, dtype=np.float32, backend=backend)
+    if dtype == np.float64:
+        get_config().use_double = True
+    dev_array = array.ones(1, dtype=dtype, backend=backend)
     with pytest.raises(ValueError):
         y = array.diff(dev_array, 1)
     y = array.diff(dev_array, 0)
     assert(y[0] == dev_array[0])
 
-    dev_array = array.ones(2, dtype=np.float32, backend=backend)
+    dev_array = array.ones(2, dtype=dtype, backend=backend)
     with pytest.raises(ValueError):
         y = array.diff(dev_array, -1)
     y = array.diff(dev_array, 1)
-    assert(y.__len__() == 1)
+    assert(len(y) == 1)
     assert(y[0] == 0)
-    dev_array = np.linspace(0, 10, 11, dtype=np.float32)**2
+    dev_array = np.linspace(0, 10, 11, dtype=dtype)**2
     yt = np.diff(dev_array, 2)
     dev_array = wrap_array(dev_array, backend=backend)
     y = array.diff(dev_array, 2)
@@ -453,12 +456,11 @@ def test_comparison(backend, dtype, method):
     x = array.arange(0., 10., 1., dtype=dtype, backend=backend)
 
     # When
-    out = x.__getattribute__(method)(5)
+    out = getattr(x, method)(5)
 
     # Then
     x_np = np.arange(10, dtype=dtype)
-    comp = [int(i) for i in x_np.__getattribute__(method)(5)]
-
+    comp = [int(i) for i in getattr(x_np, method)(5)]
     assert np.all(out.get() == comp)
 
 

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -360,3 +360,17 @@ def test_cumsum(backend):
     # Then
     out.pull()
     assert np.all(out.data == np.cumsum(a.data))
+
+
+@check_all_backends
+def test_linspace(backend):
+    check_import(backend)
+
+    dev_array = array.linspace(2, 10, 100, backend=backend)
+
+    assert(dev_array[-1] == 10)
+    dev_array = array.linspace(2, 10, 100, endpoint=False,
+                               backend=backend)
+    assert(dev_array[-1] < 10)
+    dtype = dev_array.dtype
+    assert(np.issubdtype(dtype, np.floating))


### PR DESCRIPTION
Adds many conveniences for array objects:
- Adds `linspace`, `diff`, `trapz`,  `where`
- comparison operators for an array object
- tests for above functions and `argsort`, `ones_like`, `minimum`, `sum`
- removed unnecessary import of cffi to support older versions of pycuda.