### PR TITLE
Fix a bug causing a PySPH regression.

### DIFF
--- a/compyle/template.py
+++ b/compyle/template.py
@@ -29,6 +29,7 @@ class Template(object):
         exec(src, namespace)
         f = namespace[self.name]
         f.__module__ = self.__module__
+        f.is_jit = len(annotations) == 0
         try:
             f.__annotations__ = annotations
         except AttributeError:

--- a/compyle/tests/test_jit.py
+++ b/compyle/tests/test_jit.py
@@ -16,9 +16,9 @@ def g(x):
     return x
 
 
-@annotate(x='int', return_='int')
+@annotate(x='long', return_='long')
 def g_nonjit(x):
-    return x
+    return x + 1
 
 
 @annotate
@@ -122,6 +122,9 @@ class TestAnnotationHelper(unittest.TestCase):
 
         # Then
         assert helper.external_funcs['g_nonjit'].arg_types['x'] == 'int'
+        # Should not clobber the nonjit function annotations.
+        assert g_nonjit.__annotations__['x'].type == 'long'
+        assert g_nonjit.__annotations__['return'].type == 'long'
 
     def test_subscript_as_call_arg(self):
         # Given

--- a/compyle/tests/test_template.py
+++ b/compyle/tests/test_template.py
@@ -87,6 +87,7 @@ def test_that_source_code_is_available():
         print(123)
     ''')
     assert dummy.source.strip() == expect.strip()
+    assert dummy.is_jit == True
 
 
 def test_template_usable_in_code_generation():
@@ -104,6 +105,7 @@ def test_template_usable_in_code_generation():
     # Then
     y.pull()
     np.testing.assert_almost_equal(y, 2.0*x.data)
+    assert twice.is_jit == False
 
 
 def test_template_with_extra_args():

--- a/compyle/tests/test_template.py
+++ b/compyle/tests/test_template.py
@@ -87,7 +87,7 @@ def test_that_source_code_is_available():
         print(123)
     ''')
     assert dummy.source.strip() == expect.strip()
-    assert dummy.is_jit == True
+    assert dummy.is_jit is True
 
 
 def test_template_usable_in_code_generation():
@@ -105,7 +105,7 @@ def test_template_usable_in_code_generation():
     # Then
     y.pull()
     np.testing.assert_almost_equal(y, 2.0*x.data)
-    assert twice.is_jit == False
+    assert twice.is_jit is False
 
 
 def test_template_with_extra_args():

--- a/compyle/types.py
+++ b/compyle/types.py
@@ -272,6 +272,9 @@ def annotate(func=None, **kw):
         data = kwtype_to_annotation(kw)
 
         def wrapper(func):
+            # For jitted functions, we should retain
+            # the is_jit attribute when we annotate the function.
+            func.is_jit = getattr(func, 'is_jit', False)
             try:
                 func.__annotations__ = data
             except AttributeError:


### PR DESCRIPTION
This was caused by the recent JIT reorganization.  The issue is when a
jitted function calls another function which is annotated explicitly.
When this happens, the annotation helper was clobbering the explicit
type information and this led to incorrect wrapping of a function.  We
now mark jitted functions as such and for functions for which explicit
annotations are provided the jitting does not re-annotate the function
incorrectly.