### PR TITLE
Support change backend

### DIFF
--- a/compyle/array.py
+++ b/compyle/array.py
@@ -215,6 +215,11 @@ def get_minmax_kernel(ctx, dtype, inf, mmc_dtype, prop_names,
 
 
 def wrap_array(arr, backend):
+    if isinstance(arr, Array):
+        if arr.backend == backend:
+            return arr
+        else:
+            arr = arr.data
     wrapped_array = Array(arr.dtype, allocate=False, backend=backend)
     if isinstance(arr, np.ndarray):
         wrapped_array.data = arr

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -373,7 +373,7 @@ class ElementwiseJIT(parallel.ElementwiseBase):
 
 class ReductionJIT(parallel.ReductionBase):
     def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
-                 neutral='0', backend='cython'):
+                 neutral='0', backend=None):
         backend = array.get_backend(backend)
         self.tp = Transpiler(backend=backend)
         self.backend = backend
@@ -454,7 +454,7 @@ class ReductionJIT(parallel.ReductionBase):
 class ScanJIT(parallel.ScanBase):
     def __init__(self, input=None, output=None, scan_expr="a+b",
                  is_segment=None, dtype=np.float64, neutral='0',
-                 complex_map=False, backend='opencl'):
+                 complex_map=False, backend=None):
         backend = array.get_backend(backend)
         self.tp = Transpiler(backend=backend, incl_cluda=False)
         self.backend = backend

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -7,6 +7,14 @@ import compyle.array as array
 from compyle import config
 
 
+@pytest.fixture
+def reset_use_double():
+    cfg = get_config()
+    orig = cfg.use_double
+    yield
+    get_config().use_double = orig
+
+
 check_all_backends = pytest.mark.parametrize('backend',
                                              ['cython', 'opencl', 'cuda'])
 
@@ -401,7 +409,7 @@ def test_linspace(backend):
 
 @check_all_backends
 @check_all_dtypes
-def test_diff(backend, dtype):
+def test_diff(backend, dtype, reset_use_double):
     check_import(backend)
     if dtype == np.float64:
         get_config().use_double = True
@@ -448,7 +456,7 @@ check_comparison_methods = pytest.mark.parametrize(
 @check_all_backends
 @check_all_dtypes
 @check_comparison_methods
-def test_comparison(backend, dtype, method):
+def test_comparison(backend, dtype, method, reset_use_double):
     check_import(backend)
     if dtype == np.float64:
         get_config().use_double = True
@@ -539,7 +547,7 @@ def test_sum(dtype, backend):
 
 @check_all_dtypes
 @check_all_backends
-def test_take_bool(dtype, backend):
+def test_take_bool(dtype, backend, reset_use_double):
     check_import(backend)
     if dtype == np.float64:
         get_config().use_double = True

--- a/compyle/tests/test_change_backend.py
+++ b/compyle/tests/test_change_backend.py
@@ -1,0 +1,133 @@
+import unittest
+
+import numpy as np
+from pytest import importorskip
+
+from ..config import use_config, get_config
+from ..array import wrap
+from ..types import annotate
+from ..parallel import elementwise, Reduction, Scan
+
+
+class TestChangeBackend(unittest.TestCase):
+    def test_elementwise_late_binding(self):
+        # Given/When
+        @elementwise
+        @annotate
+        def axpb(i, y, x, a, b):
+            y[i] = a*x[i] + b
+
+        # Then
+        self.assertIsNone(axpb.elementwise)
+
+    def test_reduction_late_binding(self):
+        # Given/When
+        r = Reduction('a+b')
+
+        # Then
+        self.assertIsNone(r.reduction)
+
+    def test_scan_late_binding(self):
+        # Given/When
+        @annotate
+        def output_f(i, last_item, item, ary):
+            ary[i] = item + last_item
+
+        scan = Scan(output=output_f, scan_expr='a+b',
+                    dtype=np.int32)
+
+        # Then
+        self.assertIsNone(scan.scan)
+
+    def test_elementwise_supports_changing_backend(self):
+        importorskip("pyopencl")
+
+        # Given/When
+        @elementwise
+        @annotate
+        def axpb(i, y, x, a, b):
+            y[i] = a*x[i] + b
+
+        # When
+        a, b = 2.0, 1.5
+        x = np.linspace(0, 2*np.pi, 100)
+        y = np.zeros_like(x)
+        y0 = a*x + b
+        with use_config(use_opencl=True):
+            x, y = wrap(x, y)
+            axpb(y, x, a, b)
+            y.pull()
+
+        # Then
+        np.testing.assert_array_almost_equal(y.data, y0)
+        self.assertEqual(axpb.elementwise.backend, 'opencl')
+
+        # When
+        x, y = wrap(x.data, y.data)
+        axpb.set_backend('cython')
+        axpb(y, x, a, b)
+        # Then
+        np.testing.assert_array_almost_equal(y.data, y0)
+        self.assertEqual(axpb.elementwise.backend, 'cython')
+
+    def test_reduction_supports_changing_backend(self):
+        importorskip("pyopencl")
+
+        # Given
+        r = Reduction('a+b')
+
+        # When
+        x = np.linspace(0, 1, 1000) / 1000
+        x_orig = x.copy()
+        expect = 0.5
+
+        with use_config(use_opencl=True):
+            x = wrap(x)
+            result = r(x)
+
+        # Then
+        self.assertAlmostEqual(result, expect, 6)
+
+        # When
+        x = wrap(x_orig)
+        r.set_backend('cython')
+        result = r(x)
+
+        # Then
+        self.assertAlmostEqual(result, expect, 6)
+
+    def test_scan_supports_changing_backend(self):
+        importorskip("pyopencl")
+
+        # Given/When
+        @annotate
+        def input_f(i, ary):
+            return ary[i]
+
+        @annotate
+        def output_f(i, item, ary):
+            ary[i] = item
+
+        scan = Scan(input_f, output_f, 'a+b', dtype=np.int32)
+
+        # When
+        a = np.arange(10000, dtype=np.int32)
+        data = a.copy()
+        expect = np.cumsum(a)
+
+        with use_config(use_opencl=True):
+            a = wrap(a)
+            scan(input=a, ary=a)
+            a.pull()
+
+        # Then
+        np.testing.assert_array_almost_equal(a.data, expect)
+
+        # When
+        a = wrap(data)
+        scan.set_backend('cython')
+        scan(input=a, ary=a)
+        a.pull()
+
+        # Then
+        np.testing.assert_array_almost_equal(a.data, expect)


### PR DESCRIPTION
- Support changing the backend of `Elementwise, Reduction`, and `Scan`. The backend is also bound late so it is safe to just define them and call them once the backend is set.  You can also call `kernel.set_backend()`.  If you pass nothing it will use the backend defined by the current global config, else you pass the backend explicitly.
- Allow wrapping Array instances.  This means you can call `wrap` on a `compyle.array.Array`, you can also change the backend. Note that array wrapping is not bound late so wrapped arrays should have the correct backend.