### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/compyle/cython_generator.py
+++ b/compyle/cython_generator.py
@@ -262,11 +262,7 @@ class CythonGenerator(object):
         and a list of [(arg_name, value),...].
         """
         name = meth.__name__
-        try:
-            getfullargspec = inspect.getfullargspec
-        except AttributeError:
-            # compatibility with Python 2.7
-            getfullargspec = inspect.getargspec
+        getfullargspec = inspect.getfullargspec
         argspec = getfullargspec(meth)
         args = argspec.args
         is_method = False
@@ -359,11 +355,7 @@ class CythonGenerator(object):
 
     def _get_method_body(self, meth, lines, indent=' ' * 8, declarations=None,
                          is_serial=False):
-        try:
-            getfullargspec = inspect.getfullargspec
-        except AttributeError:
-            # compatibility with Python 2.7
-            getfullargspec = inspect.getargspec
+        getfullargspec = inspect.getfullargspec
         args = set(getfullargspec(meth).args)
         src = [self._process_body_line(line, is_serial=is_serial)
                for line in lines]

--- a/compyle/cython_generator.py
+++ b/compyle/cython_generator.py
@@ -262,9 +262,11 @@ class CythonGenerator(object):
         and a list of [(arg_name, value),...].
         """
         name = meth.__name__
-        getfullargspec = getattr(
-            inspect, 'getfullargspec', inspect.getargspec
-        )
+        try:
+            getfullargspec = inspect.getfullargspec
+        except AttributeError:
+            # compatibility with Python 2.7
+            getfullargspec = inspect.getargspec
         argspec = getfullargspec(meth)
         args = argspec.args
         is_method = False
@@ -357,9 +359,11 @@ class CythonGenerator(object):
 
     def _get_method_body(self, meth, lines, indent=' ' * 8, declarations=None,
                          is_serial=False):
-        getfullargspec = getattr(
-            inspect, 'getfullargspec', inspect.getargspec
-        )
+        try:
+            getfullargspec = inspect.getfullargspec
+        except AttributeError:
+            # compatibility with Python 2.7
+            getfullargspec = inspect.getargspec
         args = set(getfullargspec(meth).args)
         src = [self._process_body_line(line, is_serial=is_serial)
                for line in lines]

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -66,8 +66,11 @@ def kernel_cache_key_kwargs(obj, **kwargs):
 
 
 def getargspec(f):
-    getargspec_f = getattr(inspect, 'getfullargspec',
-                           getattr(inspect, 'getargspec'))
+    try:
+        getargspec_f = inspect.getfullargspec
+    except AttributeError:
+        # compatibility with Python 2.7
+        getargspec_f = inspect.getargspec
     return getargspec_f(f)[0]
 
 

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -66,11 +66,7 @@ def kernel_cache_key_kwargs(obj, **kwargs):
 
 
 def getargspec(f):
-    try:
-        getargspec_f = inspect.getfullargspec
-    except AttributeError:
-        # compatibility with Python 2.7
-        getargspec_f = inspect.getargspec
+    getargspec_f = inspect.getfullargspec
     return getargspec_f(f)[0]
 
 

--- a/compyle/low_level.py
+++ b/compyle/low_level.py
@@ -153,11 +153,7 @@ class Kernel(object):
         return re.sub(r'\bdouble\b', 'float', s)
 
     def _get_func_info(self):
-        try:
-            getfullargspec = inspect.getfullargspec
-        except AttributeError:
-            # compatibility with Python 2.7
-            getfullargspec = inspect.getargspec
+        getfullargspec = inspect.getfullargspec
         argspec = getfullargspec(self.func)
         annotations = getattr(
             argspec, 'annotations', self.func.__annotations__

--- a/compyle/low_level.py
+++ b/compyle/low_level.py
@@ -153,7 +153,11 @@ class Kernel(object):
         return re.sub(r'\bdouble\b', 'float', s)
 
     def _get_func_info(self):
-        getfullargspec = getattr(inspect, 'getfullargspec', inspect.getargspec)
+        try:
+            getfullargspec = inspect.getfullargspec
+        except AttributeError:
+            # compatibility with Python 2.7
+            getfullargspec = inspect.getargspec
         argspec = getfullargspec(self.func)
         annotations = getattr(
             argspec, 'annotations', self.func.__annotations__

--- a/compyle/template.py
+++ b/compyle/template.py
@@ -6,9 +6,11 @@ from .types import kwtype_to_annotation
 import mako.template
 
 
-getfullargspec = getattr(
-    inspect, 'getfullargspec', inspect.getargspec
-)
+try:
+    getfullargspec = inspect.getfullargspec
+except AttributeError:
+    # compatibility with Python 2.7
+    getfullargspec = inspect.getargspec
 
 
 class Template(object):

--- a/compyle/template.py
+++ b/compyle/template.py
@@ -6,11 +6,7 @@ from .types import kwtype_to_annotation
 import mako.template
 
 
-try:
-    getfullargspec = inspect.getfullargspec
-except AttributeError:
-    # compatibility with Python 2.7
-    getfullargspec = inspect.getargspec
+getfullargspec = inspect.getfullargspec
 
 
 class Template(object):


### PR DESCRIPTION
Fix compatibility with Python 3.11
The patch also preserves the compatibility with Python 2.7, but probably you could drop it and simplify the code.

Closes: #93.