### PR TITLE
Remove cython runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_version():
     return data.get('__version__')
 
 
-install_requires = ['mako', 'pytools', 'cython', 'numpy']
+install_requires = ['mako', 'pytools', 'numpy']
 tests_require = ['pytest']
 if sys.version_info[0] < 3:
     tests_require += ['mock>=1.0']


### PR DESCRIPTION
Apparently cython is only needed at build time and for generated code, it is not a runtime dependency of `compyle`