### PR TITLE
Use fasteners' inter process lock ...

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -164,8 +164,6 @@ class ExtModule(object):
             yield
         finally:
             self.lck.release()
-            if exists(self.lock_path):
-                os.remove(self.lock_path)
 
     def _write_source(self, path):
         if not exists(path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ requires = [
     "numpy>=2.0,<3",
     "Cython>=0.20",
     "mako",
+    "fasteners",
     "pytools"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ mako
 pytools
 cython
 numpy
+fasteners
 pytest

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_version():
     return data.get('__version__')
 
 
-install_requires = ['mako', 'pytools', 'cython', 'numpy']
+install_requires = ['mako', 'pytools', 'cython', 'numpy', 'fasteners']
 tests_require = ['pytest']
 if sys.version_info[0] < 3:
     tests_require += ['mock>=1.0']


### PR DESCRIPTION
... instead of our own. This should sort out issues on Windows where tests fail often due to issues with locking.