### PR TITLE
Fix silly bug with platform_dir.

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -59,8 +59,10 @@ CONFIG_OPTS = get_config_file_opts()
 
 
 def get_platform_dir():
+    v = sys.version_info
+    version = '%s.%s' % (v.major, v.minor)
     return 'py{version}-{platform_dir}'.format(
-        version=sys.version[:3], platform_dir=get_platform()
+        version=version, platform_dir=get_platform()
     )
 
 


### PR DESCRIPTION
This was not setup correctly and therefore the directory for Python-3.11 was py3.1 and not py3.11. This is now fixed.