### PR TITLE
ENH: Fix fp32 performance for vortex example.

### DIFF
--- a/compyle/array.py
+++ b/compyle/array.py
@@ -312,7 +312,7 @@ def ones(n, dtype, backend='cython'):
         out = 1 + gpuarray.zeros(get_queue(), n, dtype)
     elif backend == 'cuda':
         import pycuda.gpuarray as gpuarray
-        out = np.array(1, dtype=dtype) + gpuarray.zeros(n, dtype)
+        out = 1 + gpuarray.zeros(n, dtype)
     else:
         out = np.ones(n, dtype=dtype)
     return wrap_array(out, backend)

--- a/compyle/tests/test_array.py
+++ b/compyle/tests/test_array.py
@@ -274,7 +274,8 @@ def test_sort_by_keys(backend):
     out_array1, out_array2 = array.sort_by_keys([dev_array1, dev_array2])
 
     # Then
-    if backend == 'opencl': # opencl backend => radix sort which is stable
+    if backend in ['opencl', 'cuda']:
+        # opencl/cuda backend radix sort is stable
         order = np.argsort(nparr1, stable=True)
     else:
         order = np.argsort(nparr1)

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -30,6 +30,24 @@ from .utils import getsource
 PY_VER = sys.version_info.major
 
 
+def literal_to_float(value, use_double=False):
+    """Convert numerical value to a string in 32 bit floating point notation.
+    """
+    if isinstance(value, float) and not use_double:
+        vs = str(value)
+        if 'e' in vs:
+            e_idx = vs.find('e')
+            mantissa = vs[:e_idx]
+            if '.' not in mantissa:
+                return mantissa + '.0f' + vs[(e_idx + 1):]
+            else:
+                return vs.replace('e', 'f')
+        else:
+            return vs + 'f'
+    else:
+        return str(value)
+
+
 def detect_type(name, value):
     if isinstance(value, KnownType):
         return value.type
@@ -122,6 +140,7 @@ class CStructHelper(object):
 
 class CConverter(ast.NodeVisitor):
     def __init__(self, detect_type=detect_type, known_types=None):
+        self._use_double = get_config().use_double
         self._declares = {}
         self._known = set((
             'M_E', 'M_LOG2E', 'M_LOG10E', 'M_LN2', 'M_LN10',
@@ -679,7 +698,7 @@ class CConverter(ast.NodeVisitor):
         return '!='
 
     def visit_Num(self, node):
-        return str(node.n)
+        return literal_to_float(node.n, self._use_double)
 
     def visit_Or(self, node):
         return '||'

--- a/examples/bench_vm.py
+++ b/examples/bench_vm.py
@@ -62,7 +62,7 @@ def plot_timing(n, timing):
     plt.ylabel('Speedup')
     plt.legend()
     plt.figure()
-    gflop = 10*n*n/1e9
+    gflop = 12*n*n/1e9
     plt.plot(n, gflop/timing[0], label='numba', marker='+')
     plt.plot(n, gflop/timing[1], label='Cython', marker='+')
     plt.plot(n, gflop/timing[2], label='OpenMP', marker='+')

--- a/examples/vm_elementwise.py
+++ b/examples/vm_elementwise.py
@@ -4,6 +4,7 @@ import time
 
 from compyle.config import get_config
 from compyle.api import declare, annotate
+from compyle.low_level import cast
 from compyle.parallel import Elementwise
 from compyle.array import wrap
 
@@ -13,11 +14,14 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    if r2ij < 1e-14:
+    EPS = cast(1.0e-14, "float")
+    two = cast(2.0, "float")
+    mypi = cast(pi, "float")
+    if r2ij < EPS:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(2.0*pi*r2ij)
+        tmp = gamma/(two*mypi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 
@@ -26,14 +30,16 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
 def velocity(i, x, y, gamma, u, v, nv):
     j = declare('int')
     tmp = declare('matrix(2)')
+    vx = 0.0
+    vy = 0.0
     xi = x[i]
     yi = y[i]
-    u[i] = 0.0
-    v[i] = 0.0
     for j in range(nv):
         point_vortex(xi, yi, x[j], y[j], gamma[j], tmp)
-        u[i] += tmp[0]
-        v[i] += tmp[1]
+        vx += tmp[0]
+        vy += tmp[1]
+    u[i] = vx
+    v[i] = vy
 
 
 def make_vortices(nv, backend):

--- a/examples/vm_elementwise.py
+++ b/examples/vm_elementwise.py
@@ -2,9 +2,7 @@ import numpy as np
 from math import pi
 import time
 
-from compyle.config import get_config
 from compyle.api import declare, annotate
-from compyle.low_level import cast
 from compyle.parallel import Elementwise
 from compyle.array import wrap
 
@@ -14,14 +12,11 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    EPS = cast(1.0e-14, "float")
-    two = cast(2.0, "float")
-    mypi = cast(pi, "float")
-    if r2ij < EPS:
+    if r2ij < 1e-14:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(two*mypi*r2ij)
+        tmp = gamma/(2.0*pi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 

--- a/examples/vm_elementwise_jit.py
+++ b/examples/vm_elementwise_jit.py
@@ -2,9 +2,7 @@ import numpy as np
 from math import pi
 import time
 
-from compyle.config import get_config
 from compyle.api import declare, annotate
-from compyle.low_level import cast
 from compyle.parallel import Elementwise
 from compyle.array import wrap
 
@@ -14,14 +12,11 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    EPS = cast(1.0e-14, "float")
-    two = cast(2.0, "float")
-    mypi = cast(pi, "float")
-    if r2ij < EPS:
+    if r2ij < 1.0e-14:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(two*mypi*r2ij)
+        tmp = gamma/(2.0*pi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 
@@ -31,12 +26,16 @@ def velocity(i, x, y, gamma, u, v, nv):
     tmp = declare('matrix(2)')
     xi = x[i]
     yi = y[i]
+    vx = 0.0
+    vy = 0.0
     u[i] = 0.0
     v[i] = 0.0
     for j in range(nv):
         point_vortex(xi, yi, x[j], y[j], gamma[j], tmp)
-        u[i] += tmp[0]
-        v[i] += tmp[1]
+        vx += tmp[0]
+        vy += tmp[1]
+    u[i] = vx
+    v[i] = vy
 
 
 def make_vortices(nv, backend):

--- a/examples/vm_elementwise_jit.py
+++ b/examples/vm_elementwise_jit.py
@@ -4,6 +4,7 @@ import time
 
 from compyle.config import get_config
 from compyle.api import declare, annotate
+from compyle.low_level import cast
 from compyle.parallel import Elementwise
 from compyle.array import wrap
 
@@ -13,11 +14,14 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    if r2ij < 1e-14:
+    EPS = cast(1.0e-14, "float")
+    two = cast(2.0, "float")
+    mypi = cast(pi, "float")
+    if r2ij < EPS:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(2.0*pi*r2ij)
+        tmp = gamma/(two*mypi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 

--- a/examples/vm_kernel.py
+++ b/examples/vm_kernel.py
@@ -11,8 +11,8 @@ import numpy as np
 from math import pi
 import time
 
-from compyle.api import annotate, declare, get_config, wrap
-from compyle.low_level import (Kernel, LocalMem, local_barrier, cast,
+from compyle.api import annotate, declare, wrap
+from compyle.low_level import (Kernel, LocalMem, local_barrier,
                                LID_0, LDIM_0, GDIM_0)
 
 
@@ -21,14 +21,11 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    EPS = cast(1.0e-14, "float")
-    two = cast(2.0, "float")
-    mypi = cast(pi, "float")
-    if r2ij < EPS:
+    if r2ij < 1.0e-14:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(two*mypi*r2ij)
+        tmp = gamma/(2.0*pi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 

--- a/examples/vm_kernel.py
+++ b/examples/vm_kernel.py
@@ -12,7 +12,7 @@ from math import pi
 import time
 
 from compyle.api import annotate, declare, get_config, wrap
-from compyle.low_level import (Kernel, LocalMem, local_barrier,
+from compyle.low_level import (Kernel, LocalMem, local_barrier, cast,
                                LID_0, LDIM_0, GDIM_0)
 
 
@@ -21,11 +21,14 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
     r2ij = xij*xij + yij*yij
-    if r2ij < 1e-14:
+    EPS = cast(1.0e-14, "float")
+    two = cast(2.0, "float")
+    mypi = cast(pi, "float")
+    if r2ij < EPS:
         result[0] = 0.0
         result[1] = 0.0
     else:
-        tmp = gamma/(2.0*pi*r2ij)
+        tmp = gamma/(two*mypi*r2ij)
         result[0] = -tmp*yij
         result[1] = tmp*xij
 


### PR DESCRIPTION
On cheap gaming GPUs any accidental fp64 computations, destroy performance. This PR now ensures that all float literals are handled carefully and written out as fp32 floats when `use_double` is `False`. Also doing multiple global writes is very slow, which has been fixed in the examples. The performance is now respectable. This PR also fixes all CUDA tests.