### PR TITLE
Misc improvements

### DIFF
--- a/compyle/ext_module.py
+++ b/compyle/ext_module.py
@@ -146,6 +146,12 @@ class ExtModule(object):
         )
         self.extra_link_args = extra_link_args if extra_link_args else []
 
+        if os.environ.get('COMPYLE_DEBUG') is not None:
+            self.verbose = True
+            self._debug = True
+        else:
+            self._debug = False
+
     def _add_local_include(self):
         if 'bsd' in platform.system().lower():
             local = '/usr/local/include'
@@ -269,6 +275,10 @@ class ExtModule(object):
                         force_rebuild=True,
                         setup_args={'script_args': script_args}
                     )
+                if self._debug:
+                    _out = stream.get_output()
+                    print(_out[0])
+                    print(_out[1])
             except (CompileError, LinkError):
                 hline = "*"*80
                 print(hline + "\nERROR")
@@ -311,6 +321,7 @@ class ExtModule(object):
 
     def _get_extra_args(self):
         ec, el = self.extra_compile_args, self.extra_link_args
+        ec += ['-O3']
         if get_config().use_openmp:
             _ec, _el = get_openmp_flags()
             return _ec + ec, _el + el

--- a/compyle/parallel.py
+++ b/compyle/parallel.py
@@ -29,11 +29,11 @@ cdef c_${name}(${c_arg_sig}):
 %if openmp:
     with nogil, parallel():
         for i in ${get_parallel_range("SIZE")}:
-%else:
-    if 1:
-        for i in range(SIZE):
-%endif
             ${name}(${c_args})
+%else:
+    for i in range(SIZE):
+        ${name}(${c_args})
+%endif
 
 cpdef py_${name}(${py_arg_sig}):
     c_${name}(${py_args})

--- a/compyle/transpiler.py
+++ b/compyle/transpiler.py
@@ -1,5 +1,6 @@
 import importlib
 import math
+import os
 import re
 from textwrap import dedent
 
@@ -137,6 +138,10 @@ class Transpiler(object):
         self.blocks = []
         self.mod = None
         self._use_double = get_config().use_double
+        if os.environ.get('COMPYLE_DEBUG') is not None:
+            self._debug = True
+        else:
+            self._debug = False
 
         # This attribute will store the generated and compiled source for
         # debugging.
@@ -144,7 +149,7 @@ class Transpiler(object):
         if backend == 'cython':
             self._cgen = CythonGenerator()
             self.header = dedent('''
-            # cython: language_level=3
+            # cython: language_level=3, cdivision=True
             from libc.stdio cimport printf
             from libc.math cimport *
             from libc.math cimport fabs as abs
@@ -310,3 +315,6 @@ class Transpiler(object):
             from pycuda.compiler import SourceModule
             self.source = convert_to_float_if_needed(self.get_code())
             self.mod = SourceModule(self.source)
+
+        if self._debug:
+            print(self.source)

--- a/docs/source/details.rst
+++ b/docs/source/details.rst
@@ -548,6 +548,19 @@ this will often include multiple kernels as well. Note that on CUDA the
 ``all_source`` does not show all of the sources as PyCUDA currently does not
 make it easy to inspect the code.
 
+You can define the environment variable ``COMPYLE_DEBUG``, for example on bash
+with ``export COMPYLE_DEBUG=1`` and run your code. This will print out the
+source code generated for every generated function. For CPU execution it will
+also display compiler output if there is no cached extension available.
+Turning on the debug feature can give you a lot of information, but it is very
+useful if you want to get into the gory details and do not want to edit the
+sources just to look at the generated code.
+
+It is important to note that all the Cython code is saved on disk inside the
+``~/.compyle/`` directory in a platform specific directory but no files are
+written by compyle for any OpenCL or CUDA code and in these cases the
+``COMPYLE_DEBUG`` option is very handy.
+
 
 Abstracting out arrays
 -----------------------


### PR DESCRIPTION
- Instead of using -O2 by default we now use -O3 for all Cython compilations. This can provide better performance with gcc.
- Always use cdivision=True for Cython code which leads to large improvements for Cython code performance.
- Add a `COMPYLE_DEBUG` env var option which makes it easier to debug.