### PR TITLE
BUG: Fix serious error in literal handling.

### DIFF
--- a/compyle/tests/test_translator.py
+++ b/compyle/tests/test_translator.py
@@ -21,10 +21,10 @@ def test_literal_to_float():
     # Given/When/Then
     assert literal_to_float(1.0) == '1.0f'
     assert literal_to_float(1.01325e5) == '101325.0f'
-    assert literal_to_float(1.01325e-5) == '1.01325f-05'
+    assert literal_to_float(1.01325e-5) == '1.01325e-05f'
     assert literal_to_float(1.01325E5) == '101325.0f'
-    assert literal_to_float(1.01325e-05) == '1.01325f-05'
-    assert literal_to_float(1.0e-5) == '1.0f-05'
+    assert literal_to_float(1.01325e-05) == '1.01325e-05f'
+    assert literal_to_float(1.0e-5) == '1e-05f'
     assert literal_to_float(1.0, use_double=True) == '1.0'
     assert literal_to_float(10, use_double=True) == '10'
     assert literal_to_float(1.01325e5, use_double=True) == '101325.0'

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -34,16 +34,7 @@ def literal_to_float(value, use_double=False):
     """Convert numerical value to a string in 32 bit floating point notation.
     """
     if isinstance(value, float) and not use_double:
-        vs = str(value)
-        if 'e' in vs:
-            e_idx = vs.find('e')
-            mantissa = vs[:e_idx]
-            if '.' not in mantissa:
-                return mantissa + '.0f' + vs[(e_idx + 1):]
-            else:
-                return vs.replace('e', 'f')
-        else:
-            return vs + 'f'
+        return str(value) + 'f'
     else:
         return str(value)
 


### PR DESCRIPTION
The notation for floating point with exponents in C is not the same as in julia, so 1.0e-12f is correct, but 1.0f-12 is basically -11! Entirely not what is intended. The 1.0f-12 is julia syntax. This is now fixed.