### PR TITLE
Add C backend to Compyle

### DIFF
--- a/compyle/c_backend.py
+++ b/compyle/c_backend.py
@@ -1,0 +1,322 @@
+from compyle.profile import profile
+from .translator import ocl_detect_type, KnownType
+from .cython_generator import CythonGenerator, get_func_definition
+from .cython_generator import getsourcelines
+from mako.template import Template
+from .ext_module import get_md5
+from .cimport import Cmodule
+from .transpiler import Transpiler
+from . import array
+
+import pybind11
+import numpy as np
+
+
+elwise_c_pybind = '''
+
+PYBIND11_MODULE(${modname}, m) {
+
+    m.def("${modname}", [](${pyb11_args}){
+        return ${name}(${pyb11_call});
+    });
+}
+
+'''
+
+
+class CBackend(CythonGenerator):
+    def __init__(self, detect_type=ocl_detect_type, known_types=None):
+        super(CBackend, self).__init__()
+        # self.function_address_space = 'WITHIN_KERNEL '
+
+    def get_func_signature_pyb11(self, func):
+        sourcelines = getsourcelines(func)[0]
+        defn, lines = get_func_definition(sourcelines)
+        f_name, returns, args = self._analyze_method(func, lines)
+        pyb11_args = []
+        pyb11_call = []
+        c_args = []
+        c_call = []
+        for arg, value in args:
+            c_type = self.detect_type(arg, value)
+            c_args.append('{type} {arg}'.format(type=c_type, arg=arg))
+
+            c_call.append(arg)
+            pyb11_type = self.ctype_to_pyb11(c_type)
+            pyb11_args.append('{type} {arg}'.format(type=pyb11_type, arg=arg))
+            if c_type.endswith('*'):
+                pyb11_call.append(
+                    '({ctype}){arg}.request().ptr'
+                    .format(arg=arg, ctype=c_type))
+            else:
+                pyb11_call.append('{arg}'.format(arg=arg))
+
+        return (pyb11_args, pyb11_call), (c_args, c_call)
+
+    def ctype_to_pyb11(self, c_type):
+        if c_type[-1] == '*':
+            return 'py::array_t<{}>'.format(c_type[:-1])
+        else:
+            return c_type
+
+    def _get_self_type(self):
+        return KnownType('GLOBAL_MEM %s*' % self._class_name)
+
+class CCompile(CBackend):
+    def __init__(self, func):
+        super(CCompile, self).__init__()
+        self.func = func
+        self.src = "not yet generated"
+        self.tp = Transpiler(backend='c')
+        self.c_func = self._compile()
+        
+    def _compile(self):
+        self.tp.add(self.func)
+        self.src = self.tp.get_code()
+        
+        py_data, c_data = self.get_func_signature_pyb11(self.func)
+        
+        pyb11_args = ', '.join(py_data[0][:])
+        pyb11_call = ', '.join(py_data[1][:])
+        hash_fn = get_md5(self.src)
+        modname = f'm_{hash_fn}'
+        template = Template(elwise_c_pybind)
+        src_bind = template.render(
+            name=self.func.__name__,
+            modname=modname,
+            pyb11_args=pyb11_args,
+            pyb11_call=pyb11_call
+        )
+        self.src += src_bind
+    
+        mod = Cmodule(self.src, hash_fn, openmp=False,
+                      extra_inc_dir=[pybind11.get_include()])
+        module = mod.load()
+        return getattr(module, modname)
+
+    def _massage_arg(self, x):
+        if isinstance(x, array.Array):
+            return x.dev
+        elif isinstance(x, np.ndarray):
+            return x
+        else:
+            return np.asarray(x)
+        
+    @profile
+    def __call__(self, *args, **kwargs):
+        c_args = [self._massage_arg(x) for x in args]
+        self.c_func(*c_args)
+
+elwise_c_template = '''
+
+void ${name}(${arguments}){
+    %if openmp:
+        #pragma omp parallel for
+    %endif
+        for(size_t i = 0; i < SIZE; i++){
+            ${operations};
+        }
+}
+
+'''
+
+reduction_c_template = '''
+template<typename T>
+T combine(T a, T b){
+    return ${red_expr};
+}
+
+template<typename T>
+T reduce_one_ar(int offset, int n, T initial_val, T* ary){
+    T a, b, temp;
+    temp = initial_val;
+
+    for (int i = offset; i < (n + offset); i++){
+        a = temp;
+        b = ary[i];
+
+        temp = combine<T>(a, b);
+    }
+    return temp;
+}
+
+template<typename T>
+T reduce(int offset, int n, T initial_val${args_extra}){
+    T a, b, temp;
+    temp = initial_val;
+
+    for (int i = offset; i < (n + offset); i++){
+        a = temp;
+        b = ${map_expr};
+
+        temp = combine<T>(a, b);
+    }
+    return temp;
+}
+
+
+template <typename T>
+T reduce_all(long N, T initial_val${args_extra}){
+    T ans = initial_val;
+    if (N > 0){
+        %if openmp:
+        int ntiles = omp_get_max_threads();
+        %else:
+        int ntiles = 1;
+        %endif
+        T* stage1_res = new T[ntiles];
+        %if openmp:
+        #pragma omp parallel for
+        %endif
+        {
+            // Step 1 - reducing each tile
+            %if openmp:
+            int itile = omp_get_thread_num();
+            %else:
+            int itile = 0;
+            %endif
+            int last_tile = ntiles - 1;
+            int tile_size = (N / ntiles);
+            int last_tile_sz = N - tile_size * last_tile;
+            int cur_tile_size = itile == ntiles - 1 ? last_tile_sz : tile_size;
+            int cur_start_idx = itile * tile_size;
+
+            stage1_res[itile] = reduce<T>(cur_start_idx, cur_tile_size,
+                                          initial_val${call_extra});
+            %if openmp:
+            #pragma omp barrier
+
+            #pragma omp single
+            %endif
+            ans = reduce_one_ar<T>(0, ntiles, initial_val, stage1_res);
+        }
+        delete[] stage1_res;
+    }
+    return ans;
+}
+'''
+
+reduction_c_pybind = '''
+
+PYBIND11_MODULE(${name}, m) {
+    m.def("${name}", [](long n${pyb_args}){
+        return reduce_all(n, (${type})${neutral}${pyb_call});
+    });
+}
+
+'''
+
+scan_c_template = '''
+
+template<typename T>
+T combine(T a, T b){
+    return ${scan_expr};
+}
+
+
+template<typename T>
+T reduce( T* ary, int offset, int n, T initial_val${args_in_extra}){
+    T a, b, temp;
+    temp = initial_val;
+
+    for (int i = offset; i < (n + offset); i++){
+        a = temp;
+        b = ${scan_input_expr_call};
+
+        temp = combine<T>(a, b);
+    }
+    return temp;
+}
+
+template <typename T>
+void excl_scan_wo_ip_exp( T* ary, T* out, int N, T initial_val){
+    if (N > 0){
+        T a, b, temp;
+        temp = initial_val;
+
+        for (int i = 0; i < N; i++){
+            a = temp;
+            b = ary[i];
+            out[i] = temp;
+            temp = combine<T>(a, b);
+        }
+        out[N] = temp;
+    }
+}
+
+
+template <typename T>
+void incl_scan( T* ary, int offset, int cur_buf_size, int N,
+                T initial_val, T last_item${args_extra})
+{
+    if (N > 0){
+        T a, b, carry, prev_item, item;
+        carry = initial_val;
+
+        for (int i = offset; i < (cur_buf_size + offset); i++){
+            a = carry;
+            b = ${scan_input_expr_call};
+            prev_item = carry;
+            carry = combine<T>(a, b);
+            item = carry;
+
+            ${scan_output_expr_call};
+        }
+    }
+}
+
+
+template <typename T>
+void scan( T* ary, long N, T initial_val${args_extra}){
+    if (N > 0){
+        %if openmp:
+        int ntiles = omp_get_max_threads();
+        %else:
+        int ntiles = 1;
+        %endif
+        T* stage1_res = new T[ntiles];
+        T* stage2_res = new T[ntiles + 1];
+        %if openmp:
+        #pragma omp parallel
+        %endif
+        {
+            // Step 1 - reducing each tile
+            %if openmp:
+            int itile = omp_get_thread_num();
+            %else:
+            int itile = 0;
+            %endif
+            int last_tile = ntiles - 1;
+            int tile_size = (N / ntiles);
+            int last_tile_sz = N - tile_size * last_tile;
+            int cur_tile_size = itile == ntiles - 1 ? last_tile_sz : tile_size;
+            int cur_start_idx = itile * tile_size;
+
+            stage1_res[itile] = reduce<T>(ary, cur_start_idx, cur_tile_size,
+                                          initial_val${call_in_extra});
+            %if openmp:
+            #pragma omp barrier
+
+            #pragma omp single
+            %endif
+            excl_scan_wo_ip_exp<T>(stage1_res, stage2_res,
+                                   ntiles, initial_val);
+
+            incl_scan<T>(ary, cur_start_idx, cur_tile_size, N,
+                         stage2_res[itile],stage2_res[ntiles]${call_extra});
+        }
+        delete[] stage1_res;
+        delete[] stage2_res;
+        py::print(ary);
+    }
+}
+'''
+scan_c_pybind = '''
+
+PYBIND11_MODULE(${name}, m) {
+    m.def("${name}", [](py::array_t<${type}> x, long n${pyb_args}){
+        return scan((${type}*) x.request().ptr, n,
+                    (${type})${neutral}${pyb_call});
+    });
+}
+'''

--- a/compyle/cimport.py
+++ b/compyle/cimport.py
@@ -1,0 +1,129 @@
+import os
+import io
+import importlib
+import shutil
+import sys
+from filelock import FileLock
+
+from os.path import exists, expanduser, isdir, join
+
+import pybind11
+from distutils.extension import Extension
+from distutils.command import build_ext
+from distutils.core import setup
+from distutils.errors import CompileError, LinkError
+
+from .ext_module import get_platform_dir, get_ext_extension, get_openmp_flags
+from .capture_stream import CaptureMultipleStreams  # noqa: 402
+
+
+class Cmodule:
+    def __init__(self, src, hash_fn, root=None, verbose=False, openmp=False,
+                 extra_inc_dir=[pybind11.get_include()],
+                 extra_link_args=[], extra_compile_args=[]):
+        self.src = src
+        self.hash = hash_fn
+        self.name = f'm_{self.hash}'
+        self.verbose = verbose
+        self.openmp = openmp
+        self.extra_inc_dir = extra_inc_dir
+        self.extra_link_args = extra_link_args
+        self.extra_compile_args = extra_compile_args
+        self._use_cpp11()
+
+        self._setup_root(root)
+        self._setup_filenames()
+        self.lock = FileLock(self.lock_path, timeout=120)
+
+    def _setup_root(self, root):
+        if root is None:
+            plat_dir = get_platform_dir()
+            self.root = expanduser(join('~', '.compyle', 'source', plat_dir))
+        else:
+            self.root = root
+
+        self.build_dir = join(self.root, 'build')
+
+        if not isdir(self.build_dir):
+            try:
+                os.makedirs(self.build_dir)
+            except OSError:
+                pass
+
+    def _write_source(self):
+        if not exists(self.src_path):
+            with io.open(self.src_path, 'w', encoding='utf-8') as f:
+                f.write(self.src)
+
+    def _setup_filenames(self):
+        self.src_path = join(self.root, self.name + '.cpp')
+        self.ext_path = join(self.root, self.name + get_ext_extension())
+        self.lock_path = join(self.root, self.name + '.lock')
+
+    def is_build_needed(self):
+        return not exists(self.ext_path)
+
+    def build(self):
+        self._include_openmp()
+        ext = Extension(name=self.name,
+                        sources=[self.src_path],
+                        language='c++',
+                        include_dirs=self.extra_inc_dir,
+                        extra_link_args=self.extra_link_args,
+                        extra_compile_args=self.extra_compile_args)
+        args = [
+            "build_ext",
+            "--build-lib=" + self.build_dir,
+            "--build-temp=" + self.build_dir,
+            "-v",
+        ]
+
+        try:
+            with CaptureMultipleStreams() as stream:
+                setup(name=self.name,
+                      ext_modules=[ext],
+                      script_args=args,
+                      cmdclass={"build_ext": build_ext.build_ext})
+                shutil.move(join(self.build_dir, self.name +
+                            get_ext_extension()), self.ext_path)
+
+        except(CompileError, LinkError, SystemExit):
+            hline = "*"*80
+            print(hline + "\nERROR")
+            s_out = stream.get_output()
+            print(s_out[0])
+            print(s_out[1])
+            msg = "Compilation of code failed, please check "\
+                "error messages above."
+            print(hline + "\n" + msg)
+            sys.exit(1)
+
+    def write_and_build(self):
+        """Write source and build the extension module"""
+        if self.is_build_needed():
+            with self.lock:
+                self._write_source()
+                self.build()
+        else:
+            self._message("Precompiled code from:", self.src_path)
+
+    def load(self):
+        self.write_and_build()
+        spec = importlib.util.spec_from_file_location(self.name, self.ext_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _include_openmp(self):
+        if self.openmp:
+            ec, el = get_openmp_flags()
+            self.extra_compile_args += ec
+            self.extra_link_args += el
+
+    def _use_cpp11(self):
+        self.extra_compile_args += ['-std=c++11']
+
+    def _message(self, *args):
+        msg = ' '.join(args)
+        if self.verbose:
+            print(msg)

--- a/compyle/tests/test_c_backend.py
+++ b/compyle/tests/test_c_backend.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import TestCase
+from ..c_backend import CBackend, CCompile
+from ..types import annotate
+import numpy as np
+
+
+class TestCBackend(TestCase):
+    def test_get_func_signature(self):
+        cbackend = CBackend()
+
+        @annotate(x='int', y='intp', z='int', w='double')
+        def test_fn(x, y, z=2, w=3.0):
+            return x+y+z+w
+        temp = cbackend.get_func_signature(test_fn)
+        (pyb11_args, pyb11_call), (c_args, c_call) = temp
+        exp_pyb11_args = ['int x', 'int[:] y', 'int z', 'double w']
+        exp_pyb11_call = ['x', '&y[0]', 'z', 'w']
+        exp_c_args = ['int x', 'int* y', 'int z', 'double w']
+        exp_c_call = ['x', 'y', 'z', 'w']
+
+        self.assertListEqual(pyb11_args, exp_pyb11_args)
+        self.assertListEqual(pyb11_call, exp_pyb11_call)
+        self.assertListEqual(c_args, exp_c_args)
+        self.assertListEqual(c_call, exp_c_call)
+
+class TestCCompile(TestCase):
+    def test_compile(self):
+        @annotate(int='n, p', intp='x, y')
+        def get_pow(n, p, x, y):
+            for i in range(n):
+                y[i] = x[i]**p
+        c_get_pow = CCompile(get_pow)
+        n = 5
+        p = 5
+        x = np.ones(n, dtype=np.int32) * 2
+        y = np.zeros(n, dtype=np.int32)
+        y_exp = np.ones(n, dtype=np.int32) * 32
+        c_get_pow(n, p, x, y)
+        assert(np.all(y == y_exp))
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/compyle/tests/test_cimport.py
+++ b/compyle/tests/test_cimport.py
@@ -1,0 +1,65 @@
+from genericpath import exists
+from ntpath import join
+import tempfile
+import unittest
+from unittest import TestCase
+import numpy as np
+from os.path import exists, expanduser, isdir, join
+import sys
+import os
+from mako.template import Template
+
+
+from compyle.cimport import Cmodule
+from compyle.types import annotate
+from compyle.ext_module import get_platform_dir, get_md5, get_ext_extension
+
+dummy_module = '''
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+namespace py = pybind11;
+
+void f(int n, int* x, int* y)
+{
+    for(int i = 0; i < n; i++){
+        y[i] = (2 * x[i]);
+    }
+}
+'''
+pybind = """
+
+PYBIND11_MODULE(${name}, m) {
+
+    m.def("${name}", [](py::array_t<int> x, py::array_t<int> y){
+        return f(x.request().size, (int*)x.request().ptr,
+        (int*)y.request().ptr);
+    });
+}
+"""
+
+
+class TestCmodule(TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def test_build(self):
+        hash_fn = get_md5(dummy_module)
+        name = f'm_{hash_fn}'
+        pyb_template = Template(pybind)
+        src_pybind = pyb_template.render(name=name)
+
+        all_src = dummy_module + src_pybind
+        mod = Cmodule(all_src, hash_fn=hash_fn, root=self.root)
+        checksum = get_md5(dummy_module)
+        self.assertTrue(mod.is_build_needed())
+
+        mod.load()
+        self.assertTrue(exists(join(self.root, 'build')))
+        self.assertTrue(exists(join(self.root, 'm_' + checksum + '.cpp')))
+        self.assertTrue(
+            exists(join(self.root, f'{name}' + get_ext_extension())))
+        self.assertFalse(mod.is_build_needed())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/compyle/tests/test_parallel.py
+++ b/compyle/tests/test_parallel.py
@@ -19,6 +19,65 @@ def external(x):
     return x
 
 
+class ParallelUtilsBaseC(object):
+    def test_elementwise_works_with_c(self):
+        self._check_simple_elementwise(backend='c')
+
+    def test_elementwise_works_with_global_constant_c(self):
+        self._check_elementwise_with_constant(backend='c')
+
+    def test_reduction_works_without_map_c(self):
+        self._check_simple_reduction(backend='c')
+
+    def test_reduction_works_with_map_c(self):
+        self._check_reduction_with_map(backend='c')
+
+    def test_reduction_works_with_external_func_c(self):
+        self._check_reduction_with_external_func(backend='c')
+
+    def test_reduction_works_neutral_c(self):
+        self._check_reduction_min(backend='c')
+
+    def test_scan_works_c(self):
+        self._test_scan(backend='c')
+
+    def test_scan_works_c_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan(backend='c')
+
+    def test_large_scan_works_c_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_large_scan(backend='c')
+
+    def test_scan_works_with_external_func_c(self):
+        self._test_scan_with_external_func(backend='c')
+
+    def test_scan_works_with_external_func_c_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan_with_external_func(backend='c')
+
+    def test_scan_last_item_c_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan_last_item(backend='c')
+
+    def test_scan_last_item_c_serial(self):
+        self._test_scan_last_item(backend='c')
+
+    def test_unique_scan_c(self):
+        self._test_unique_scan(backend='c')
+
+    def test_unique_scan_c_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_unique_scan(backend='c')
+
+    def test_repeated_scans_with_different_settings_c(self):
+        with use_config(use_openmp=False):
+            self._test_unique_scan(backend='c')
+
+        with use_config(use_openmp=True):
+            self._test_unique_scan(backend='c')
+
+
 class ParallelUtilsBase(object):
     def test_elementwise_works_with_cython(self):
         self._check_simple_elementwise(backend='cython')
@@ -221,7 +280,9 @@ class ParallelUtilsBase(object):
             self._test_unique_scan(backend='cython')
 
 
-class TestParallelUtils(ParallelUtilsBase, unittest.TestCase):
+class TestParallelUtils(ParallelUtilsBase,
+                        ParallelUtilsBaseC,
+                        unittest.TestCase):
     def setUp(self):
         cfg = get_config()
         self._use_double = cfg.use_double

--- a/compyle/transpiler.py
+++ b/compyle/transpiler.py
@@ -9,7 +9,7 @@ from mako.template import Template
 from .config import get_config
 from .ast_utils import get_unknown_names_and_calls
 from .cython_generator import CythonGenerator, CodeGenerationError
-from .translator import OpenCLConverter, CUDAConverter, literal_to_float
+from .translator import OpenCLConverter, CUDAConverter, CConverter, literal_to_float
 from .ext_module import ExtModule
 from .extern import Extern, get_extern_code
 from .utils import getsourcelines
@@ -194,6 +194,15 @@ class Transpiler(object):
             #define max(x, y) fmax((double)(x), (double)(y))
 
             ''')
+        elif backend == 'c':
+            self._cgen = CConverter()
+            self.header = dedent('''
+                // c code for with PyBind11 binding
+                #include <pybind11/pybind11.h>
+                #include <pybind11/numpy.h>
+                namespace py = pybind11;
+                using namespace std;
+                ''')
 
     def _handle_symbol(self, name, value):
         backend = self.backend
@@ -223,6 +232,8 @@ class Transpiler(object):
             return '#define {name} {value}'.format(
                 name=name, value=literal_to_float(value, self._use_double)
             )
+        elif self.backend == 'c':
+            return f"{ctype} {name} = {value};"
 
     def _get_comment(self):
         return '#' if self.backend == 'cython' else '//'
@@ -282,6 +293,10 @@ class Transpiler(object):
                 if declarations else None, is_serial=is_serial)
             code = self._cgen.get_code()
         elif self.backend == 'opencl' or self.backend == 'cuda':
+            code = self._cgen.parse(
+                obj, declarations=declarations.get(obj.__name__)
+                if declarations else None)
+        elif self.backend == 'c':
             code = self._cgen.parse(
                 obj, declarations=declarations.get(obj.__name__)
                 if declarations else None)

--- a/compyle/utils.py
+++ b/compyle/utils.py
@@ -40,7 +40,7 @@ class ArgumentParser(argparse.ArgumentParser):
         # setup standard arguments
         self.add_argument(
             '-b', '--backend', action='store', dest='backend', default='cython',
-            choices = ['cython', 'opencl', 'cuda'],
+            choices = ['cython', 'opencl', 'cuda', 'c'],
             help='Choose the backend.'
         )
         self.add_argument(

--- a/examples/bench_vm.py
+++ b/examples/bench_vm.py
@@ -33,7 +33,8 @@ def compare(m=5):
     N = np.array([10, 50, 100, 200, 500, 1000, 2000, 4000, 6000,
                   8000, 10000, 15000, 20000])
     backends = [(VN, '', False), (VE, 'cython', False), (VE, 'cython', True),
-                (VE, 'opencl', False), (VK, 'opencl', False)]
+                (VE, 'opencl', False), (VK, 'opencl', False),
+                (VE, 'c', False), (VE, 'c', True)]
     timing = []
     for backend in backends:
         e = setup(*backend)
@@ -57,6 +58,8 @@ def plot_timing(n, timing):
     plt.plot(n, timing[0]/timing[2], label='numba/openmp', marker='+')
     plt.plot(n, timing[0]/timing[3], label='numba/opencl', marker='+')
     plt.plot(n, timing[0]/timing[4], label='numba/opencl local', marker='+')
+    plt.plot(n, timing[5]/timing[1], label='c/cython', marker='+')
+    plt.plot(n, timing[6]/timing[2], label='c-openmp/openmp', marker='+')
     plt.grid()
     plt.xlabel('N')
     plt.ylabel('Speedup')
@@ -68,6 +71,8 @@ def plot_timing(n, timing):
     plt.plot(n, gflop/timing[2], label='OpenMP', marker='+')
     plt.plot(n, gflop/timing[3], label='OpenCL', marker='+')
     plt.plot(n, gflop/timing[4], label='OpenCL Local', marker='+')
+    plt.plot(n, gflop/timing[5], label='C', marker='+')
+    plt.plot(n, gflop/timing[6], label='C-OpenMP', marker='+')
     plt.grid()
     plt.xlabel('N')
     plt.ylabel('GFLOPS')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pytools
 cython
 numpy
 pytest
+pybind11
+filelock


### PR DESCRIPTION
 ## Add C backend to Compyle

  ### Summary

  - Adds a new `c` backend that transpiles annotated Python functions to C and compiles them via pybind11, enabling direct C
  execution without the Cython overhead.
  - Introduces `CBackend` (in `c_backend.py`) — a `CythonGenerator` subclass that generates pybind11 binding code alongside the C
   source, and `CCompile` for single-function compilation.
  - Extends `Elementwise`, `Reduction`, and `Scan` in `parallel.py` to support `backend='c'`, generating templated C kernels with
   pybind11 bindings.

  ### Unit tests
  - `tests/test_c_backend.py` — new unit tests for `CBackend`/`CCompile`
  - `tests/test_cimport.py` — new unit tests for `Cmodule`
  -  `tests/test_parallel.py` — extended parallel primitive tests covering the `c` backend