### PR TITLE
Fix CUDA minmax collector copies from volatile shared memory

### DIFF
--- a/compyle/array.py
+++ b/compyle/array.py
@@ -97,6 +97,22 @@ minmax_tpl = """
 
 minmax_operator_tpl = """
 
+    __device__ ${dtype}()
+    {
+    }
+
+    __device__ ${dtype}(${dtype} const volatile &src)
+    {
+        % for prop in prop_names:
+        % if not only_max:
+        this->cur_min_${prop} = src.cur_min_${prop};
+        % endif
+        % if not only_min:
+        this->cur_max_${prop} = src.cur_max_${prop};
+        % endif
+        % endfor
+    }
+
     __device__ ${dtype} volatile &operator=(
         ${dtype} const &src) volatile
     {

--- a/compyle/array.py
+++ b/compyle/array.py
@@ -303,7 +303,8 @@ def to_device(array, backend='cython'):
         out = gpuarray.to_device(get_queue(), array)
     elif backend == 'cuda':
         import pycuda.gpuarray as gpuarray
-        out = gpuarray.to_gpu(array)
+        from .cuda import get_cuda_allocator
+        out = gpuarray.to_gpu(array, allocator=get_cuda_allocator())
     return wrap_array(out, backend)
 
 
@@ -341,7 +342,8 @@ def empty(n, dtype, backend='cython'):
         out = gpuarray.empty(get_queue(), n, dtype)
     elif backend == 'cuda':
         import pycuda.gpuarray as gpuarray
-        out = gpuarray.empty(n, dtype)
+        from .cuda import get_cuda_allocator
+        out = gpuarray.empty(n, dtype, allocator=get_cuda_allocator())
     else:
         out = np.empty(n, dtype=dtype)
     return wrap_array(out, backend)
@@ -358,7 +360,8 @@ def zeros(n, dtype, backend='cython'):
         out = gpuarray.zeros(get_queue(), n, dtype)
     elif backend == 'cuda':
         import pycuda.gpuarray as gpuarray
-        out = gpuarray.zeros(n, dtype)
+        from .cuda import get_cuda_allocator
+        out = gpuarray.zeros(n, dtype, allocator=get_cuda_allocator())
     else:
         out = np.zeros(n, dtype=dtype)
     return wrap_array(out, backend)

--- a/compyle/ast_utils.py
+++ b/compyle/ast_utils.py
@@ -9,6 +9,18 @@ PY_VER = sys.version_info.major
 basestring = str if PY_VER > 2 else basestring
 
 
+def get_string_value(node):
+    """Return a string literal's value or None if *node* is not a string."""
+    ast_constant = getattr(ast, 'Constant', None)
+    if ast_constant is not None and isinstance(node, ast_constant) and \
+            isinstance(node.value, str):
+        return node.value
+    ast_str = getattr(ast, 'Str', None)
+    if ast_str is not None and isinstance(node, ast_str):
+        return node.s
+    return None
+
+
 class NameLister(ast.NodeVisitor):
     """Utility class to collect the Names in an AST.
     """

--- a/compyle/cuda.py
+++ b/compyle/cuda.py
@@ -1396,7 +1396,8 @@ class _GenericScanKernelBase(object):
 
 generic_scan_kernel_cache = WriteOncePersistentDict(
     "pycuda-generated-scan-kernel-cache-v1",
-    key_builder=_NumpyTypesKeyBuilder())
+    key_builder=_NumpyTypesKeyBuilder(),
+    safe_sync=False)
 
 
 class GenericScanKernel(_GenericScanKernelBase):

--- a/compyle/cuda.py
+++ b/compyle/cuda.py
@@ -18,6 +18,7 @@ from pytools import memoize
 import numpy as np
 import six
 _cuda_ctx = False
+_cuda_memory_pool = None
 
 
 def set_context():
@@ -25,6 +26,15 @@ def set_context():
     if not _cuda_ctx:
         import pycuda.autoinit
         _cuda_ctx = True
+
+
+def get_cuda_allocator():
+    global _cuda_memory_pool
+    set_context()
+    if _cuda_memory_pool is None:
+        from pycuda.tools import DeviceMemoryPool
+        _cuda_memory_pool = DeviceMemoryPool()
+    return _cuda_memory_pool.allocate
 
 
 # The following code is taken from pyopencl for struct mapping.

--- a/compyle/cython_generator.py
+++ b/compyle/cython_generator.py
@@ -21,7 +21,7 @@ from mako.template import Template
 
 from .types import KnownType, Undefined, get_declare_info
 from .config import get_config
-from .ast_utils import get_assigned, has_return
+from .ast_utils import get_assigned, get_string_value, has_return
 from .utils import getsourcelines
 
 logger = logging.getLogger(__name__)
@@ -247,11 +247,12 @@ def parse_declare(code):
     if call.func.id != 'declare':
         raise CodeGenerationError('Unknown declare statement: %s' % code)
     arg0 = call.args[0]
-    if not isinstance(arg0, ast.Str):
-        err = 'Type should be a string, given :%r' % arg0.s
+    type_str = get_string_value(arg0)
+    if type_str is None:
+        err = 'Type should be a string, given :%r' % getattr(arg0, 'value', arg0)
         raise CodeGenerationError(err)
 
-    return get_declare_info(arg0.s)
+    return get_declare_info(type_str)
 
 
 class CythonGenerator(object):

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -8,6 +8,7 @@ import warnings
 import time
 from pytools import memoize
 from .config import get_config
+from .ast_utils import get_string_value
 from .cython_generator import CythonGenerator
 from .transpiler import Transpiler, BUILTINS
 from .types import (dtype_to_ctype, get_declare_info,
@@ -198,15 +199,16 @@ class AnnotationHelper(ast.NodeVisitor):
         warnings.warn(msg)
 
     def visit_declare(self, node):
-        if not isinstance(node.args[0], ast.Str):
+        type_str = get_string_value(node.args[0])
+        if type_str is None:
             self.error("Argument to declare should be a string.", node)
-        type_str = node.args[0].s
         return self.get_declare_type(type_str)
 
     def visit_cast(self, node):
-        if not isinstance(node.args[1], ast.Str):
+        type_str = get_string_value(node.args[1])
+        if type_str is None:
             self.error("Cast type should be a string.", node)
-        return node.args[1].s
+        return type_str
 
     def visit_address(self, node):
         base_type = self.visit(node.args[0])
@@ -293,6 +295,11 @@ class AnnotationHelper(ast.NodeVisitor):
 
     def visit_Num(self, node):
         return get_ctype_from_arg(node.n)
+
+    def visit_Constant(self, node):
+        if isinstance(node.value, str):
+            return None
+        return get_ctype_from_arg(node.value)
 
     def visit_UnaryOp(self, node):
         return self.visit(node.operand)

--- a/compyle/jit.py
+++ b/compyle/jit.py
@@ -370,11 +370,12 @@ class ElementwiseJIT(parallel.ElementwiseBase):
             c_func(*c_args, **kw)
             self.queue.finish()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             c_func(*c_args, **kw)
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
 
 
 class ReductionJIT(parallel.ReductionBase):
@@ -449,11 +450,12 @@ class ReductionJIT(parallel.ReductionBase):
             self.queue.finish()
             return result.get()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             result = c_func(*c_args, **kw)
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
             return result.get()
 
 
@@ -569,8 +571,9 @@ class ScanJIT(parallel.ScanBase):
             c_func(*[c_args_dict[k] for k in output_arg_keys])
             self.queue.finish()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             c_func(*[c_args_dict[k] for k in output_arg_keys])
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()

--- a/compyle/low_level.py
+++ b/compyle/low_level.py
@@ -260,15 +260,16 @@ class Kernel(object):
             self.knl(*c_args)
             self.queue.finish()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
             shared_mem_size = int(self._get_local_size(args, ls[0]))
             num_blocks = int((n + ls[0] - 1) / ls[0])
             num_tpb = int(ls[0])
-            event = drv.Event()
             self.knl(*c_args, block=(num_tpb, 1, 1), grid=(num_blocks, 1),
                      shared=shared_mem_size)
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
 
 
 class _prange(Extern):

--- a/compyle/parallel.py
+++ b/compyle/parallel.py
@@ -547,11 +547,12 @@ class ElementwiseBase(object):
             self.c_func(*c_args, **kw)
             self.queue.finish()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             self.c_func(*c_args, **kw)
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
 
 
 class Elementwise(object):
@@ -809,11 +810,12 @@ class ReductionBase(object):
             self.queue.finish()
             return result.get()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             result = self.c_func(*c_args)
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
             return result.get()
 
 
@@ -1229,11 +1231,12 @@ class ScanBase(object):
             self.c_func(*[c_args_dict[k] for k in output_arg_keys])
             self.queue.finish()
         elif self.backend == 'cuda':
-            import pycuda.driver as drv
-            event = drv.Event()
             self.c_func(*[c_args_dict[k] for k in output_arg_keys])
-            event.record()
-            event.synchronize()
+            if get_config().profile:
+                import pycuda.driver as drv
+                event = drv.Event()
+                event.record()
+                event.synchronize()
 
 
 class Scan(object):

--- a/compyle/profile.py
+++ b/compyle/profile.py
@@ -179,9 +179,16 @@ def profile_kernel(kernel, name, backend=None):
             _record_profile(name, end - start)
             return event
         elif backend == 'cuda':
-            exec_time = kernel(*args, **kwargs, time_kernel=True)
-            _record_profile(name, exec_time)
-            return exec_time
+            from pycuda import driver as cuda
+            stream = kwargs.get('stream')
+            start = cuda.Event()
+            end = cuda.Event()
+            start.record(stream)
+            result = kernel(*args, **kwargs)
+            end.record(stream)
+            end.synchronize()
+            _record_profile(name, end.time_since(start) * 1e-3)
+            return result
         else:
             start = time.time()
             kernel(*args, **kwargs)

--- a/compyle/template.py
+++ b/compyle/template.py
@@ -9,6 +9,13 @@ import mako.template
 getfullargspec = inspect.getfullargspec
 
 
+def _string_value(node):
+    value = node.value
+    if isinstance(value, ast.Constant):
+        return value.value
+    return value.s
+
+
 class Template(object):
     def __init__(self, name):
         self.name = name
@@ -45,8 +52,8 @@ class Template(object):
         args += extra_args
         arg_string = ', '.join(args)
         body = m.body[0].body
-        template = body[-1].value.s
-        docstring = body[0].value.s if len(body) == 2 else ''
+        template = _string_value(body[-1])
+        docstring = _string_value(body[0]) if len(body) == 2 else ''
         name = self.name
         sig = 'def {name}({args}):\n    """{docs}\n    """'.format(
             name=name, args=arg_string, docs=docstring

--- a/compyle/tests/test_jit.py
+++ b/compyle/tests/test_jit.py
@@ -1,12 +1,16 @@
 from math import sin
 import unittest
 import numpy as np
+from unittest.mock import patch
 
 from pytest import importorskip
 
 from ..config import get_config, use_config
 from ..array import wrap
-from ..jit import get_binop_return_type, AnnotationHelper
+from ..jit import (
+    AnnotationHelper, ElementwiseJIT, ReductionJIT, ScanJIT,
+    get_binop_return_type
+)
 from ..types import annotate
 from ..parallel import Elementwise, Reduction, Scan
 
@@ -30,6 +34,91 @@ def h(a, b):
 def undeclared_f(a, b):
     h_ab = h(a, b)
     return g(h_ab)
+
+
+class TestCUDAJITSynchronization(unittest.TestCase):
+    def _patch_cuda_event(self):
+        sync_calls = []
+
+        class FakeEvent:
+            def record(self):
+                pass
+
+            def synchronize(self):
+                sync_calls.append("sync")
+
+        return sync_calls, patch("pycuda.driver.Event", FakeEvent)
+
+    def test_cuda_elementwise_jit_does_not_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        @annotate
+        def axpb(i, x):
+            x[i] = x[i] + 1.0
+
+        kernel = ElementwiseJIT(axpb, backend="cuda")
+        kernel._generate_kernel = lambda *args: lambda *c_args, **kw: None
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            kernel(np.zeros(8))
+
+        assert sync_calls == []
+
+    def test_cuda_scan_jit_does_not_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        @annotate(input="doublep", return_="double")
+        def input_expr(i, input):
+            return input[i]
+
+        @annotate(output="doublep", item="double")
+        def output_expr(i, item, output):
+            output[i] = item
+
+        scan = ScanJIT(input=input_expr, output=output_expr, backend="cuda")
+        output_expr.arg_keys = {scan._get_backend_key(): ["input", "output"]}
+        scan._generate_kernel = lambda **kwargs: lambda *c_args: None
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            scan(input=np.zeros(8), output=np.zeros(8))
+
+        assert sync_calls == []
+
+    def test_cuda_reduction_jit_does_not_event_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        class FakeResult:
+            def get(self):
+                return 1.0
+
+        reduction = ReductionJIT("a+b", backend="cuda")
+        reduction._generate_kernel = (
+            lambda *args: lambda *c_args, **kw: FakeResult()
+        )
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            assert reduction(np.zeros(8)) == 1.0
+
+        assert sync_calls == []
+
+    def test_cuda_elementwise_jit_synchronizes_with_profile(self):
+        importorskip("pycuda")
+
+        @annotate
+        def axpb(i, x):
+            x[i] = x[i] + 1.0
+
+        kernel = ElementwiseJIT(axpb, backend="cuda")
+        kernel._generate_kernel = lambda *args: lambda *c_args, **kw: None
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=True), event_patch:
+            kernel(np.zeros(8))
+
+        assert sync_calls == ["sync"]
 
 
 class TestAnnotationHelper(unittest.TestCase):

--- a/compyle/tests/test_low_level.py
+++ b/compyle/tests/test_low_level.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from unittest.mock import patch
 
 from pytest import importorskip
 
@@ -13,6 +14,52 @@ from ..low_level import (
 
 
 class TestKernel(unittest.TestCase):
+    def _patch_cuda_event(self):
+        sync_calls = []
+
+        class FakeEvent:
+            def record(self):
+                pass
+
+            def synchronize(self):
+                sync_calls.append("sync")
+
+        return sync_calls, patch("pycuda.driver.Event", FakeEvent)
+
+    def _make_cuda_kernel(self):
+        class FakeArray:
+            data = np.zeros(8)
+
+        kernel = object.__new__(Kernel)
+        kernel.backend = "cuda"
+        kernel.knl = lambda *c_args, **kw: None
+        kernel._get_workgroup_size = lambda n: ((8,), (128,))
+        kernel._get_args = lambda args, workgroup_size: []
+        kernel._get_local_size = lambda args, workgroup_size: 0
+        return kernel, FakeArray()
+
+    def test_cuda_kernel_does_not_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        kernel, fake_array = self._make_cuda_kernel()
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            kernel(fake_array)
+
+        assert sync_calls == []
+
+    def test_cuda_kernel_synchronizes_with_profile(self):
+        importorskip("pycuda")
+
+        kernel, fake_array = self._make_cuda_kernel()
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=True), event_patch:
+            kernel(fake_array)
+
+        assert sync_calls == ["sync"]
+
     def test_simple_kernel_opencl(self):
         importorskip('pyopencl')
 

--- a/compyle/tests/test_parallel.py
+++ b/compyle/tests/test_parallel.py
@@ -1,17 +1,98 @@
 from math import sin
 import unittest
 import numpy as np
+from unittest.mock import patch
 
 from pytest import importorskip
 
 from ..config import get_config, use_config
 from ..array import wrap, zeros
 from ..types import annotate, declare
-from ..parallel import Elementwise, Reduction, Scan
+from ..parallel import (
+    Elementwise, ElementwiseBase, Reduction, ReductionBase, Scan, ScanBase
+)
 from ..low_level import atomic_inc, atomic_dec
 from .test_jit import g
 
 MY_CONST = 42
+
+
+class TestCUDAParallelSynchronization(unittest.TestCase):
+    def _patch_cuda_event(self):
+        sync_calls = []
+
+        class FakeEvent:
+            def record(self):
+                pass
+
+            def synchronize(self):
+                sync_calls.append("sync")
+
+        return sync_calls, patch("pycuda.driver.Event", FakeEvent)
+
+    def test_cuda_elementwise_base_does_not_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        kernel = object.__new__(ElementwiseBase)
+        kernel.backend = "cuda"
+        kernel.c_func = lambda *c_args, **kw: None
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            kernel(np.zeros(8))
+
+        assert sync_calls == []
+
+    def test_cuda_reduction_base_does_not_event_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        class FakeResult:
+            def get(self):
+                return 1.0
+
+        reduction = object.__new__(ReductionBase)
+        reduction.backend = "cuda"
+        reduction.c_func = lambda *c_args: FakeResult()
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            assert reduction(np.zeros(8)) == 1.0
+
+        assert sync_calls == []
+
+    def test_cuda_scan_base_does_not_synchronize_without_profile(self):
+        importorskip("pycuda")
+
+        class OutputFunc:
+            pass
+
+        scan = object.__new__(ScanBase)
+        scan.backend = "cuda"
+        scan._config = get_config()
+        scan.c_func = lambda *c_args: None
+        scan.output_func = OutputFunc()
+        scan.output_func.arg_keys = {
+            scan._get_backend_key(): ["input", "output"]
+        }
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=False), event_patch:
+            scan(input=np.zeros(8), output=np.zeros(8))
+
+        assert sync_calls == []
+
+    def test_cuda_elementwise_base_synchronizes_with_profile(self):
+        importorskip("pycuda")
+
+        kernel = object.__new__(ElementwiseBase)
+        kernel.backend = "cuda"
+        kernel.c_func = lambda *c_args, **kw: None
+        sync_calls, event_patch = self._patch_cuda_event()
+
+        with use_config(profile=True), event_patch:
+            kernel(np.zeros(8))
+
+        assert sync_calls == ["sync"]
 
 
 @annotate(x='int', return_='int')

--- a/compyle/translator.py
+++ b/compyle/translator.py
@@ -25,6 +25,7 @@ from .types import get_declare_info
 from .cython_generator import (
     CodeGenerationError, KnownType, Undefined, all_numeric
 )
+from .ast_utils import get_string_value
 from .utils import getsource
 
 PY_VER = sys.version_info.major
@@ -235,7 +236,7 @@ class CConverter(ast.NodeVisitor):
 
     def _remove_docstring(self, body):
         if body and isinstance(body[0], ast.Expr) and \
-                isinstance(body[0].value, ast.Str):
+                get_string_value(body[0].value) is not None:
             return body[1:]
         else:
             return body
@@ -351,9 +352,9 @@ class CConverter(ast.NodeVisitor):
         left, right = node.targets[0], node.value
         if isinstance(right, ast.Call) and \
            isinstance(right.func, ast.Name) and right.func.id == 'declare':
-            if not isinstance(right.args[0], ast.Str):
+            type = get_string_value(right.args[0])
+            if type is None:
                 self.error("Argument to declare should be a string.", node)
-            type = right.args[0].s
             if isinstance(left, ast.Name):
                 self._known.add(left.id)
                 return self._get_variable_declaration(type, [self.visit(left)])
@@ -395,7 +396,10 @@ class CConverter(ast.NodeVisitor):
             elif 'atomic' in node.func.id:
                 return self.render_atomic(node.func.id, node.args[0])
             elif node.func.id == 'cast':
-                return '(%s) (%s)' % (node.args[1].s, self.visit(node.args[0]))
+                type_str = get_string_value(node.args[1])
+                if type_str is None:
+                    self.error("Cast type should be a string.", node)
+                return '(%s) (%s)' % (type_str, self.visit(node.args[0]))
             else:
                 return '{func}({args})'.format(
                     func=node.func.id,
@@ -681,6 +685,14 @@ class CConverter(ast.NodeVisitor):
             return self._replacements[value]
         else:
             return value
+
+    def visit_Constant(self, node):
+        value = node.value
+        if value is True or value is False or value is None:
+            return self._replacements[value]
+        if isinstance(value, str):
+            return r'"%s"' % value
+        return literal_to_float(value, self._use_double)
 
     def visit_Not(self, node):
         return '!'

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,16 @@ def get_version():
     return data.get('__version__')
 
 
-install_requires = ['mako', 'pytools', 'cython', 'numpy']
+install_requires = [
+    'mako', 'pytools', 'cython', 'numpy', 'setuptools>=42.0.0'
+]
 tests_require = ['pytest']
 if sys.version_info[0] < 3:
     tests_require += ['mock>=1.0']
 docs_require = ['sphinx']
-cuda_require = ['pycuda', 'cupy']
+cuda_require = ['pycuda', 'cupy', 'six']
+cuda12x_require = ['pycuda', 'cupy-cuda12x', 'six']
+cuda13x_require = ['pycuda', 'cupy-cuda13x', 'six']
 opencl_require = ['pyopencl']
 
 classes = '''
@@ -73,6 +77,8 @@ setup(
         "tests": tests_require,
         "dev": docs_require + tests_require,
         "cuda": cuda_require,
+        "cuda12x": cuda12x_require,
+        "cuda13x": cuda13x_require,
         "opencl": opencl_require,
     },
 )


### PR DESCRIPTION
Fixes #98.

The bug is in Compyle's CUDA min/max collector when it is used with PyCUDA's final warp reduction.

Compyle passes the generated collector to `pycuda.reduction.ReductionKernel` with:

```python
reduce_expr="agg_mmc(a, b)",
map_expr="mmc_from_scalar(%s)" % map_args,
```

https://github.com/pypr/compyle/blob/d738bf564492132c6770d2602661f2d06dac1da8/compyle/array.py#L209-L212

The generated reducer takes the collector by value:

```cpp
WITHIN_KERNEL ${dtype} agg_mmc(${dtype} a, ${dtype} b)
```

https://github.com/pypr/compyle/blob/d738bf564492132c6770d2602661f2d06dac1da8/compyle/array.py#L77-L92

In [PyCUDA](https://github.com/inducer/pycuda/blob/19bed9035edb9990b2928e297125d8e9d470130b/pycuda/reduction.py#L134-L143
), the final warp reduction reads and writes shared memory through `volatile out_type *smem`:

```cpp
if (tid < 32)
{
  // 'volatile' required according to Fermi compatibility guide 1.2.2
  volatile out_type *smem = sdata;
  if (BLOCK_SIZE >= 64) smem[tid] = REDUCE(smem[tid], smem[tid + 32]);
  if (BLOCK_SIZE >= 32) smem[tid] = REDUCE(smem[tid], smem[tid + 16]);
  if (BLOCK_SIZE >= 16) smem[tid] = REDUCE(smem[tid], smem[tid + 8]);
  if (BLOCK_SIZE >= 8)  smem[tid] = REDUCE(smem[tid], smem[tid + 4]);
  if (BLOCK_SIZE >= 4)  smem[tid] = REDUCE(smem[tid], smem[tid + 2]);
  if (BLOCK_SIZE >= 2)  smem[tid] = REDUCE(smem[tid], smem[tid + 1]);
}
```

So `REDUCE(smem[tid], smem[tid + offset])` copies `volatile out_type` values into the by-value `agg_mmc` parameters.

Before this patch, Compyle only generated a volatile assignment operator for the collector:

```cpp
__device__ ${dtype} volatile &operator=(
    ${dtype} const &src) volatile
```

https://github.com/pypr/compyle/blob/d738bf564492132c6770d2602661f2d06dac1da8/compyle/array.py#L98-L112

That handles writing the reduced result back to `smem[tid]`, but it does not define how to read from `volatile out_type` into `agg_mmc`.

This patch adds a constructor from `const volatile &`. That constructor is called when `smem[tid]` or `smem[tid + offset]` is copied into the by-value `agg_mmc` arguments, and it explicitly loads each collector field from the volatile source.

The following construction makes the access pattern visible. The `-1` values are not harmless placeholders. They are deliberately placed at positions that should participate in the full reduction, but are not observed by lane 0 when the volatile shared-memory updates are missed.

```python
import numpy as np
from compyle import array

x = array.wrap_array(np.array([
    0,
    1,
    2, -1,
    4, -1, -1, -1,
    8, -1, -1, -1, -1, -1, -1, -1,
    16, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
    32, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    64,
    65,
    66, -1,
    68, -1, -1, -1,
    72, -1, -1, -1, -1, -1, -1, -1,
    90, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    128, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
]), backend="cuda")

array.update_minmax_gpu([x], backend="cuda")
print(x.minimum, x.maximum)
```

With the bug, the computed minimum is still `0`, even though the true minimum is `-1`. If the marked `-1` positions are replaced by `1000`, the computed maximum still does not change. This shows that those values are present in the input but are not reaching the final result.

This matches [PyCUDA's reduction tree](https://github.com/inducer/pycuda/blob/19bed9035edb9990b2928e297125d8e9d470130b/pycuda/reduction.py#L137-L143). In the final warp stage, lane 0 combines values through offsets `32, 16, 8, 4, 2, 1`:

```cpp
volatile out_type *smem = sdata;
if (BLOCK_SIZE >= 64) smem[tid] = REDUCE(smem[tid], smem[tid + 32]);
if (BLOCK_SIZE >= 32) smem[tid] = REDUCE(smem[tid], smem[tid + 16]);
if (BLOCK_SIZE >= 16) smem[tid] = REDUCE(smem[tid], smem[tid + 8]);
if (BLOCK_SIZE >= 8)  smem[tid] = REDUCE(smem[tid], smem[tid + 4]);
if (BLOCK_SIZE >= 4)  smem[tid] = REDUCE(smem[tid], smem[tid + 2]);
if (BLOCK_SIZE >= 2)  smem[tid] = REDUCE(smem[tid], smem[tid + 1]);
```

The values placed at `0, 1, 2, 4, 8, 16, 32, ...` are exactly the ones lane 0 can still see in the broken path. The marked `-1` values require intermediate `smem[...]` updates from other lanes to be visible. Without the `const volatile &` collector constructor, those intermediate volatile shared-memory updates can be missed.

For the original example in #98, `a1 = np.asarray([4.2, 2.0, 0.01, 0.08, 4.0, 29.2], dtype=np.float32)`, Compyle set `ca1.maximum=4.2` because the broken path effectively computes only `max(4.2, 2.0, 0.01, 4.0)`.
